### PR TITLE
Change root_path to return relative path when error

### DIFF
--- a/lib/dynamo/filters/static.ex
+++ b/lib/dynamo/filters/static.ex
@@ -57,7 +57,12 @@ defmodule Dynamo.Filters.Static do
   end
 
   defp root_path(root) when is_atom(root) do
-    File.join :code.lib_dir(root), "priv/static"
+    case :code.lib_dir(root) do
+      {:error, :bad_name} ->
+        "priv/static"
+      root_dir ->
+        File.join root_dir, "priv/static"
+    end
   end
 
   defp root_path(root) when is_binary(root) do


### PR DESCRIPTION
:code.lib_dir(root) return {:error, :bad_name} in heroku.
So I change root_path/1 to return relative path when lib_dir/1 return error.

Thanks.
