### PR TITLE
Generate an empty favicon

### DIFF
--- a/lib/mix/tasks/dynamo.ex
+++ b/lib/mix/tasks/dynamo.ex
@@ -84,6 +84,7 @@ defmodule Mix.Tasks.Dynamo do
 
     create_directory "priv"
     create_directory "priv/static"
+    create_file "priv/static/favicon.ico", ""
 
     create_directory "test"
     create_file "test/test_helper.exs", test_helper_template(assigns)


### PR DESCRIPTION
So we won't get an error when we visit a newly created project.
