### PR TITLE
Support for http patch method

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ defmodule ApplicationRouter do
 end
 ```
 
-All routers must use the `Dynamo.Router` module. By using this module, we have access to the macros `get`, `post`, `put` and `delete` that allows developers to generate routes. Here is a simple route:
+All routers must use the `Dynamo.Router` module. By using this module, we have access to the macros `get`, `post`, `put`, `patch` and `delete` that allows developers to generate routes. Here is a simple route:
 
 ```elixir
 get "/hello/world" do

--- a/lib/dynamo/http/case.ex
+++ b/lib/dynamo/http/case.ex
@@ -46,7 +46,7 @@ defmodule Dynamo.HTTP.Case do
       end
 
   The example above will automatically work, since
-  `get`/`post`/`put`/`delete` recycles the connection before
+  `get`/`post`/`put`/`patch`/`delete` recycles the connection before
   each request.
 
   When recycled, all response information previously set in
@@ -74,7 +74,7 @@ defmodule Dynamo.HTTP.Case do
 
   If the connection was already recycled, it won't be recycled once again.
 
-  Finally, notice that all `get`/`post`/`put`/`delete` macros
+  Finally, notice that all `get`/`post`/`put`/`patch`/`delete` macros
   are simply a proxy to `process/4`. So in case you want to dispatch
   to different dynamos at the same time, `process/4` may be useful.
   """
@@ -127,6 +127,17 @@ defmodule Dynamo.HTTP.Case do
   """
   defmacro put(arg1, arg2 // nil) do
     do_method :PUT, arg1, arg2
+  end
+
+  @doc """
+  Does a PATCH request to the given path:
+
+      patch("/foo")
+      patch(conn, "/foo")
+
+  """
+  defmacro patch(arg1, arg2 // nil) do
+    do_method :PATCH, arg1, arg2
   end
 
   @doc """

--- a/lib/dynamo/router/base.ex
+++ b/lib/dynamo/router/base.ex
@@ -34,7 +34,7 @@ defmodule Dynamo.Router.Base do
 
   In the example above, a request will only match if it is
   a `GET` request and the route "/hello". The supported
-  verbs are `get`, `post`, `put` and `delete`.
+  verbs are `get`, `post`, `put`, `patch` and `delete`.
 
   A route can also specify parameters which will then be
   available in the function body:
@@ -290,6 +290,14 @@ defmodule Dynamo.Router.Base do
   """
   defmacro put(path, contents) do
     compile(:generate_match, path, Keyword.merge(contents, via: :put))
+  end
+
+  @doc """
+  Dispatches to the path only if it is patch request.
+  See `match/3` for more examples.
+  """
+  defmacro patch(path, contents) do
+    compile(:generate_match, path, Keyword.merge(contents, via: :patch))
   end
 
   @doc """

--- a/test/dynamo/router/base_test.exs
+++ b/test/dynamo/router/base_test.exs
@@ -134,6 +134,7 @@ defmodule Dynamo.Router.BaseTest do
     assert get("/8/foo").assigns[:value] == 8
     assert post("/8/foo").assigns[:value] == 8
     assert put("/8/foo").assigns[:value] == 8
+    assert patch("/8/foo").assigns[:value] == 8
     assert delete("/8/foo").assigns[:value] == 8
   end
 


### PR DESCRIPTION
I have added support for the PATCH method described in RFC 5798 because I am porting an API that uses the PATCH method to dynamo to see how it works.
