### PR TITLE
Add documentation for route globbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ put "/users/:user_id" do
 end
 ```
 
+```elixir
+get "/hello/*glob" do
+  conn.resp 200, "Wildcard matched on all remaining segments after /hello/: #{conn.params[:glob]}"
+end
+```
+
 Each route is compiled down to a function clause, this makes routes matching extremely fast and also allow the use of guard constraints:
 
 ```elixir

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ end
 ```
 
 ```elixir
-get "/hello/*glob" do
-  conn.resp 200, "Wildcard matched on all remaining segments after /hello/: #{conn.params[:glob]}"
+get "/hello/*" do
+  conn.resp 200, "Match all routes starting with /hello"
 end
 ```
 

--- a/lib/dynamo/router/base.ex
+++ b/lib/dynamo/router/base.ex
@@ -43,6 +43,14 @@ defmodule Dynamo.Router.Base do
         conn.resp 200, "hello \#{name}"
       end
 
+  Routes allow for globbing which will match the remaining parts
+  of a route and will be available as a parameter in the function
+  body, also note that *glob can't be followed by other segments:
+
+      get "/hello/*glob" do
+        conn.resp 200, "hello \#{glob}"
+      end
+
   Finally, a general `match` function is also supported:
 
       match "/hello" do

--- a/lib/dynamo/router/base.ex
+++ b/lib/dynamo/router/base.ex
@@ -44,11 +44,15 @@ defmodule Dynamo.Router.Base do
       end
 
   Routes allow for globbing which will match the remaining parts
-  of a route and will be available as a parameter in the function
-  body, also note that *glob can't be followed by other segments:
+  of a route and can be available as a parameter in the function
+  body, also note that a glob can't be followed by other segments:
+
+      get "/hello/*" do
+        conn.resp 200, "match all routes starting with /hello"
+      end
 
       get "/hello/*glob" do
-        conn.resp 200, "hello \#{glob}"
+        conn.resp 200, "route after /hello: \#{glob}"
       end
 
   Finally, a general `match` function is also supported:


### PR DESCRIPTION
There is no documentation that states that routes can match on globs. Should be added to the documentation of `Dynamo.Router.Base` and maybe the README walk-through of routers?

Example:

``` elixir
match "/hello/*glob" do
  conn.resp 200, "world"
end
```
