### PR TITLE
Added check for already loaded modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/elixir-lang/dynamo.png?branch=master)](https://travis-ci.org/elixir-lang/dynamo)
+
 # Dynamo
 
 Run, Dynamo, Run!

--- a/lib/mix/tasks/dynamo.ex
+++ b/lib/mix/tasks/dynamo.ex
@@ -100,6 +100,9 @@ defmodule Mix.Tasks.Dynamo do
     unless name =~ %r/^[a-z][\w_]+$/ do
       raise Mix.Error, message: "project path must start with a letter and have only lowercase letters, numbers and underscore"
     end
+    if Code.ensure_loaded?(Module.concat([String.capitalize(name)])) do
+      raise Mix.Error, message: "the name is already used by a dynamo module"
+    end
   end
 
   embed_template :readme, """

--- a/test/mix/tasks/dynamo_test.exs
+++ b/test/mix/tasks/dynamo_test.exs
@@ -11,9 +11,11 @@ defmodule Mix.Tasks.DynamoTest do
   end
 
   test "throws an error if the designated app name is a module used by dynamo" do
-    error = %r(the name is already used by a dynamo module)
-    output = System.cmd "mix dynamo /tmp/dynamo"
-    assert output =~ error
+    in_tmp "wrong_name", fn ->
+      assert_raise Mix.Error, "the name is already used by a dynamo module", fn ->
+        Mix.Tasks.Dynamo.run ["dynamo"]
+      end
+    end
   end
 
   test "generates a new dynamo app" do

--- a/test/mix/tasks/dynamo_test.exs
+++ b/test/mix/tasks/dynamo_test.exs
@@ -10,6 +10,12 @@ defmodule Mix.Tasks.DynamoTest do
     assert_received { :mix_shell, :info, ["Dynamo v" <> _] }
   end
 
+  test "throws an error if the designated app name is a module used by dynamo" do
+    error = %r(the name is already used by a dynamo module)
+    output = System.cmd "mix dynamo /tmp/dynamo"
+    assert output =~ error
+  end
+
   test "generates a new dynamo app" do
     in_tmp "my_app", fn ->
       Mix.Tasks.Dynamo.run ["."]


### PR DESCRIPTION
If generating a new Dynamo app via Mix, this checks if the name of an already loaded module is used as the project name, as this would break the build system.
