### PR TITLE
fix places where super was expecting to use implicit arguments

### DIFF
--- a/lib/dynamo/loader.ex
+++ b/lib/dynamo/loader.ex
@@ -141,7 +141,7 @@ defmodule Dynamo.Loader do
   end
 
   def handle_call(_arg, _from, _config) do
-    super
+    super(_arg, _from, _config)
   end
 
   @doc false
@@ -159,7 +159,7 @@ defmodule Dynamo.Loader do
   end
 
   def handle_cast(_arg, _config) do
-    super
+    super(_arg, _config)
   end
 
   ## Helpers

--- a/lib/dynamo/static.ex
+++ b/lib/dynamo/static.ex
@@ -61,7 +61,7 @@ defmodule Dynamo.Static do
   end
 
   def handle_call(_msg, _from, _config) do
-    super
+    super(_msg, _from, _config)
   end
 
   ## Server helpers

--- a/lib/dynamo/templates/renderer.ex
+++ b/lib/dynamo/templates/renderer.ex
@@ -110,7 +110,7 @@ defmodule Dynamo.Templates.Renderer do
   end
 
   def handle_call(_arg, _from, _config) do
-    super
+    super(_arg, _from, _config)
   end
 
   def handle_cast(:clear, { name, dict }) do
@@ -127,7 +127,7 @@ defmodule Dynamo.Templates.Renderer do
   end
 
   def handle_cast(_arg, _config) do
-    super
+    super(_arg, _config)
   end
 
   ## Server Helpers


### PR DESCRIPTION
implicit arguments to super was deprecated in 0.9.2
