### PR TITLE
fix deprecation warning for File.iterator! -> File.stream!

### DIFF
--- a/lib/dynamo/filters/exceptions/debug.ex
+++ b/lib/dynamo/filters/exceptions/debug.ex
@@ -125,7 +125,7 @@ defmodule Dynamo.Filters.Exceptions.Debug do
   def extract_snippet(original, line) do
     if File.regular?(original) do
       to_discard = max(line - @radius - 1, 0)
-      lines = File.iterator!(original) |> Enum.take(line + 5) |> Enum.drop(to_discard)
+      lines = File.stream!(original) |> Enum.take(line + 5) |> Enum.drop(to_discard)
 
       { first_five, lines } = Enum.split(lines, line - to_discard - 1)
       first_five = with_line_number first_five, to_discard + 1, false


### PR DESCRIPTION
Fixes the following deprecation warnings when running the tests

```
[WARNING] File.iterator!/2 is deprecated, please use File.stream!/2 instead
    /Users/reset/code/elixir/lib/elixir/lib/file.ex:972: File.iterator!/2
    /Users/reset/code/dynamo/lib/dynamo/filters/exceptions/debug.ex:128: Dynamo.Filters.Exceptions.Debug.extract_snippet/2
    /Users/reset/code/dynamo/lib/dynamo/filters/exceptions/debug.ex:111: Dynamo.Filters.Exceptions.Debug.file_context/4
    /Users/reset/code/dynamo/lib/dynamo/filters/exceptions/debug.ex:63: Dynamo.Filters.Exceptions.Debug.each_frame/5
    /Users/reset/code/elixir/lib/elixir/lib/enum.ex:686: Enum."-map_reduce/3-fun-0-"/3
    /Users/reset/code/elixir/lib/elixir/lib/enum.ex:1518: Enumerable.List.reduce/3
    /Users/reset/code/elixir/lib/elixir/lib/enum.ex:685: Enum.map_reduce/3
```
