### PR TITLE
fix deprecation warning for Code.string_to_ast! -> Code.string_to_quoted!

### DIFF
--- a/lib/dynamo.ex
+++ b/lib/dynamo.ex
@@ -235,7 +235,7 @@ defmodule Dynamo do
     env = dynamo[:env]
     if dir && File.dir?(dir) do
       file = "#{dir}/#{env}.exs"
-      Code.string_to_ast! File.read!(file), file: file
+      Code.string_to_quoted! File.read!(file), file: file
     end
   end
 


### PR DESCRIPTION
Fixes this warning when starting the server with `mix server`

```
[WARNING] Code.string_to_ast! is deprecated, please use Code.string_to_quoted! instead
    /Users/reset/code/elixir/lib/elixir/lib/code.ex:228: Code.string_to_ast!/2
    src/elixir_dispatch.erl:189: :elixir_dispatch.expand_macro_fun/7
    src/elixir_dispatch.erl:167: :elixir_dispatch.expand_require/6
    src/elixir_dispatch.erl:104: :elixir_dispatch.dispatch_require/6
    src/elixir_module.erl:341: :elixir_module."-eval_callbacks/5-fun-1-"/6
    lists.erl:1313: :lists.foreach/2
    src/elixir_module.erl:148: :elixir_module.eval_form/5
```
