### PR TITLE
Fixes unexpected comma error in base router.

### DIFF
--- a/lib/dynamo/router/base.ex
+++ b/lib/dynamo/router/base.ex
@@ -267,7 +267,7 @@ defmodule Dynamo.Router.Base do
     what = Keyword.get(options, :to, nil)
 
     unless what, do:
-      raise ArgumentError, message: "Expected to: to be given to forward"
+      raise(ArgumentError, message: "Expected to: to be given to forward")
 
     block =
       quote do


### PR DESCRIPTION
This error causes Dynamo to fail at compile with a stack trace similar to this:

```
** (SyntaxError) /Users/cloud/Projects/open-source/storyteller/deps/dynamo/lib/dynamo/router/base.ex:270: unexpected comma. Parentheses are required to solve ambiguity in nested calls. Syntax error before: ','
src/elixir_parser.yrl:621: :elixir_parser.throw/3
src/elixir_parser.yrl:377: :elixir_parser.yeccpars2_282/7
/usr/local/Cellar/erlang/R16B/lib/erlang/lib/parsetools-2.0.9/include/yeccpre.hrl:56: :elixir_parser.yeccpars0/5
src/elixir_translator.erl:16: :elixir_translator.forms/4
src/elixir_translator.erl:28: :elixir_translator.forms!/4
src/elixir_compiler.erl:24: :elixir_compiler.string/2
src/elixir_compiler.erl:48: :elixir_compiler.file_to_path/2
/Users/cloud/Projects/open-source/elixir/lib/elixir/lib/kernel/parallel_compiler.ex:68: Kernel.ParallelCompiler."-spawn_compilers/7-fun-0-"/3
```
