### PR TITLE
Updates out of date dependencies message in test.

### DIFF
--- a/test/mix/tasks_test.exs
+++ b/test/mix/tasks_test.exs
@@ -90,7 +90,7 @@ defmodule Mix.TasksTest do
   test "warns on missing dependencies" do
     in_tmp "missing_deps", fn ->
       Mix.Tasks.Dynamo.run [".", "--dev"]
-      error = %r(Some dependencies are out of date)
+      error = %r(Can't continue due to errors on dependencies)
 
       output = System.cmd "mix server"
       assert output =~ error


### PR DESCRIPTION
Small failure in the following test:

```
  1) test warns on missing dependencies (Mix.TasksTest)
 ** (ExUnit.ExpectationError)
        expected: "Unchecked dependencies for environment dev:\n* mimetypes [git: \"git://github.com/spawngrid/mimetypes.git\"]\n  the dependency is not available, run `mix deps.get`\n* cowboy [git: \"git://github.com/extend/cowboy.git\"]\n  the dependency is not available, run `mix deps.get`\n** (Mix) Can't continue due to errors on dependencies\n"
   to match (=~): %r"Some dependencies are out of date"
 stacktrace:
   test/mix/tasks_test.exs:96: Mix.TasksTest."-test warns on missing dependencies/1-fun-0-"/0
   /Users/cloud/Projects/open-source/elixir/lib/elixir/lib/file.ex:904: File.cd!/2
   test/mix/tasks_test.exs:91: Mix.TasksTest."test warns on missing dependencies"/1
```

I've updated the message. Test suite passes with with https://github.com/elixir-lang/dynamo/pull/91 merged back in.

Unrelated: syntax highlight is weird in Vim for this regex, may need some investigation.
