### PR TITLE
fix regular expression for matching mix dynamo.filters to allow for vary...

### DIFF
--- a/test/mix/tasks_test.exs
+++ b/test/mix/tasks_test.exs
@@ -36,7 +36,7 @@ defmodule Mix.TasksTest do
 
       output = System.cmd "mix dynamo.filters"
       assert output =~ %r(filter Dynamo.Filters.Head)
-      assert output =~ %r(filter \{Dynamo.Filters.Loader,true,true\})
+      assert output =~ %r(filter \{Dynamo.Filters.Loader, *true, *true\})
       assert output =~ %r(ApplicationRouter.service/1)
 
       # Check it works with first compilation in prod


### PR DESCRIPTION
...ing amounts of white space

The output from "mix dynamo.filters" has spaces after the commas and the test pattern did not allow for that.
