### PR TITLE
Fixing call to update manifest in Compile.Dynamo.

### DIFF
--- a/lib/mix/tasks/compile.dynamo.ex
+++ b/lib/mix/tasks/compile.dynamo.ex
@@ -69,12 +69,13 @@ defmodule Mix.Tasks.Compile.Dynamo do
       to_compile = Mix.Utils.extract_files(source_paths, compile_exts)
       File.mkdir_p!(compile_path)
       Code.delete_path compile_path
-
-      { _current, to_remove } =
-        Mix.Utils.manifest manifest, fn ->
-          compiled = compile_files to_compile, compile_path, root
-          lc { mod, _ } inlist compiled, do: atom_to_binary(mod)
-        end
+      
+      to_remove = Mix.Utils.read_manifest manifest
+      
+      compiled = compile_files to_compile, compile_path, root
+      current  = lc { mod, _ } inlist compiled, do: atom_to_binary(mod)
+      
+      Mix.Utils.update_manifest manifest, current
 
       compile_templates mod, dynamo[:compiled_templates], templates, compile_path
 


### PR DESCRIPTION
After this alteration https://github.com/elixir-lang/elixir/commit/c0a6dc4b47847510e440cb92d1748a6b20142362#L1L111, Compile.Dynamo task crashed.

This commit fix this.
