### PR TITLE
Preserve original path in Dynamo.Connection.Test

### DIFF
--- a/lib/dynamo/connection/test.ex
+++ b/lib/dynamo/connection/test.ex
@@ -22,7 +22,7 @@ defmodule Dynamo.Connection.Test do
 
   use Dynamo.Connection.Behaviour,
     [ :query_string, :raw_req_headers, :raw_req_body, :raw_req_cookies, :fetched,
-      :path_segments, :sent_body, :original_method, :scheme, :port ]
+      :path, :path_segments, :sent_body, :original_method, :scheme, :port ]
 
   @doc """
   Initializes a connection to be used in tests.
@@ -60,8 +60,8 @@ defmodule Dynamo.Connection.Test do
   end
 
   @doc false
-  def path(connection(path_segments: path_segments)) do
-    to_path path_segments
+  def path(connection(path: path)) do
+    path
   end
 
   @doc false
@@ -217,6 +217,7 @@ defmodule Dynamo.Connection.Test do
       method: method,
       original_method: method,
       params: nil,
+      path: uri.path,
       path_info_segments: segments,
       path_segments: segments,
       query_string: uri.query || "",

--- a/test/dynamo/connection/test_test.exs
+++ b/test/dynamo/connection/test_test.exs
@@ -29,6 +29,7 @@ defmodule Dynamo.Connection.TestTest do
 
     assert conn(:GET, "/foo/bar").path == "/foo/bar"
     assert conn(:GET, "/").path == "/"
+    assert conn(:GET, "/foo/bar/").path == "/foo/bar/"
   end
 
   test :query_string do

--- a/test/dynamo/cowboy/connection_test.exs
+++ b/test/dynamo/cowboy/connection_test.exs
@@ -72,9 +72,15 @@ defmodule Dynamo.Cowboy.ConnectionTest do
     conn
   end
 
+  def path_2(conn) do
+    assert conn.path == "/path_2/foo/bar/baz/"
+    conn
+  end
+
   test :path do
     assert_success request :get, "/path_0"
     assert_success request :get, "/path_1/foo/bar/baz"
+    assert_success request :get, "/path_2/foo/bar/baz/"
   end
 
   def query_string_0(conn) do


### PR DESCRIPTION
Existing method reconstructed path from segments which dropped the trailing / if was present. Cowboy preserves this in its conn.path so this keeps consistency between the test and live environments.
