### PR TITLE
adding link element to point to the provided favicon

### DIFF
--- a/lib/mix/tasks/dynamo.ex
+++ b/lib/mix/tasks/dynamo.ex
@@ -184,6 +184,7 @@ defmodule Mix.Tasks.Dynamo do
   <html>
   <head>
     <title><%%= @title %></title>
+    <link rel="shortcut icon" href="/static/favicon.ico" />
   </head>
   <body>
     <h3>Welcome to Dynamo!</h3>


### PR DESCRIPTION
It's a minor annoyance, but still one that can be fixed.

Browsers will attempt to download a favorites icon at /favicon.ico.  Since the favicon.ico for a newly minted dynamo is located at /static/favicon.ico, this results in a 404 in the console.

This patch adds an element to correct the discrepancy and remove the 404.
