### PR TITLE
Added convenience function to delete data from a session given a key

### DIFF
--- a/lib/dynamo/http/session.ex
+++ b/lib/dynamo/http/session.ex
@@ -27,7 +27,7 @@ defmodule Dynamo.HTTP.Session do
   @doc """
   Removes the session for the given key
   """
-  def del_session(conn, key) do    
+  def delete_session(conn, key) do    
     private = conn.private
     session = List.keydelete(get_session(conn), key, 0)
     mark_as_writen conn.put_private(@session, session), private

--- a/lib/dynamo/http/session.ex
+++ b/lib/dynamo/http/session.ex
@@ -25,6 +25,15 @@ defmodule Dynamo.HTTP.Session do
   end
 
   @doc """
+  Removes the session for the given key
+  """
+  def del_session(conn, key) do    
+    private = conn.private
+    session = List.keydelete(get_session(conn), key, 0)
+    mark_as_writen conn.put_private(@session, session), private
+  end
+
+  @doc """
   Puts the session for the given key.
   """
   def put_session(conn, key, value) do

--- a/test/dynamo/http/session_test.exs
+++ b/test/dynamo/http/session_test.exs
@@ -9,13 +9,13 @@ defmodule Dynamo.HTTP.SessionTest do
     assert get_session(conn, :test_get_session) == "123"
   end
 
-  test :del_session do
-    conn = conn(:GET, "/").put_private(:dynamo_session, [test_del_session: "123"])
+  test :delete_session do
+    conn = conn(:GET, "/").put_private(:dynamo_session, [test_delete_session: "123"])
     conn = conn.put_private(:dynamo_session_opts, {0, false, []})
     
-    assert get_session(conn, :test_del_session) == "123"
-    conn = del_session(conn, :test_del_session)
-    assert get_session(conn, :test_del_session) == nil
+    assert get_session(conn, :test_delete_session) == "123"
+    conn = delete_session(conn, :test_delete_session)
+    assert get_session(conn, :test_delete_session) == nil
 
   end
 

--- a/test/dynamo/http/session_test.exs
+++ b/test/dynamo/http/session_test.exs
@@ -1,0 +1,23 @@
+defmodule Dynamo.HTTP.SessionTest do
+  use ExUnit.Case, async: true
+  use Dynamo.HTTP.Case
+  import Dynamo.HTTP.Session
+
+  test :get_session do
+    conn = conn(:GET, "/").put_private(:dynamo_session, [test_get_session: "123"])
+    assert get_session(conn, :test_no_such_session) == nil
+    assert get_session(conn, :test_get_session) == "123"
+  end
+
+  test :del_session do
+    conn = conn(:GET, "/").put_private(:dynamo_session, [test_del_session: "123"])
+    conn = conn.put_private(:dynamo_session_opts, {0, false, []})
+    
+    assert get_session(conn, :test_del_session) == "123"
+    conn = del_session(conn, :test_del_session)
+    assert get_session(conn, :test_del_session) == nil
+
+  end
+
+
+end


### PR DESCRIPTION
Dynamo.HTTP.Session has the ability to put and to get data from the session, but not to delete. I've added a function to delete data from the session, also a simple test for session.
