### PR TITLE
Fix issue #102 by starting asn1

### DIFF
--- a/lib/dynamo/app.ex
+++ b/lib/dynamo/app.ex
@@ -9,7 +9,6 @@ defmodule Dynamo.App do
   """
   def start do
     :application.start(:crypto)
-    :application.start(:asn1)
     :application.start(:mimetypes)
 
     case :application.start(:dynamo) do

--- a/lib/dynamo/app.ex
+++ b/lib/dynamo/app.ex
@@ -9,6 +9,7 @@ defmodule Dynamo.App do
   """
   def start do
     :application.start(:crypto)
+    :application.start(:asn1)
     :application.start(:mimetypes)
 
     case :application.start(:dynamo) do

--- a/lib/dynamo/cowboy.ex
+++ b/lib/dynamo/cowboy.ex
@@ -43,6 +43,7 @@ defmodule Dynamo.Cowboy do
 
     if ssl do
       :application.start(:crypto)
+      :application.start(:asn1)
       :application.start(:public_key)
       :application.start(:ssl)
       https = https_options(main, Keyword.merge(options, ssl))


### PR DESCRIPTION
As I understand it, in R16B01 you need to start asn1, see : https://groups.google.com/forum/#!topic/erlang-programming/04KztstCX5k

and this commit on hackney might be interesting: https://github.com/Raynes/hackney/commit/7cccb6eed250ab0acf12d1b19b527f55dc3d262f

Not sure if this is backward compatible with R16 though. @josevalim you didn't have to issue to start with, so does this still work for you?

Not too sure on how to go about this, should this be started only in an ssl context? 
