### PR TITLE
Fixed deprecation warning from crypto

### DIFF
--- a/lib/dynamo/utils/message_verifier.ex
+++ b/lib/dynamo/utils/message_verifier.ex
@@ -33,7 +33,7 @@ defmodule Dynamo.Utils.MessageVerifier do
   end
 
   defp digest(secret, data) do
-    <<mac :: [integer, size(160)]>> = :crypto.sha_mac(secret, data)
+    <<mac :: [integer, size(160)]>> = :crypto.hmac(:sha, secret, data)
     :erlang.integer_to_list(mac, 16) |> iolist_to_binary
   end
 
@@ -61,3 +61,4 @@ defmodule Dynamo.Utils.MessageVerifier do
     acc
   end
 end
+


### PR DESCRIPTION
lib/dynamo/utils/message_verifier.ex:36: crypto:sha_mac/2 is deprecated and will be removed in in a future release; use crypto:hmac/3

Note that this seems not to be backwards compatible for erlang. The guys over at erlang-oauth ended up with an if/else : https://github.com/tim/erlang-oauth/pull/19

Do you want something similar?
