### PR TITLE
An attempt at implementing basic support for websockets

### DIFF
--- a/lib/dynamo/connection.ex
+++ b/lib/dynamo/connection.ex
@@ -314,6 +314,12 @@ defmodule Dynamo.Connection do
   defcallback sendfile(status, path :: binary, conn) :: conn
 
   @doc """
+  Request to upgrade the connection to a websocket connection.
+  The module is a cowboy websocket handler.
+  """
+  defcallback upgrade_to_websocket(module, Keyword.t, conn) :: conn
+
+  @doc """
   Returns the response state. It can be:
 
   * `:unset` - the response was not configured yet

--- a/lib/dynamo/connection/test.ex
+++ b/lib/dynamo/connection/test.ex
@@ -21,8 +21,9 @@ defmodule Dynamo.Connection.Test do
   """
 
   use Dynamo.Connection.Behaviour,
-    [ :query_string, :raw_req_headers, :raw_req_body, :raw_req_cookies, :fetched,
-      :path, :path_segments, :sent_body, :original_method, :scheme, :port ]
+    [ :query_string, :raw_req_headers, :raw_req_body, :raw_req_cookies,
+      :fetched, :path, :path_segments, :sent_body, :original_method,
+      :scheme, :port, :websocket_handler, :websocket_init ]
 
   @doc """
   Initializes a connection to be used in tests.
@@ -143,6 +144,17 @@ defmodule Dynamo.Connection.Test do
       state: :sent,
       sent_body: check_sent_body(conn, File.read!(path)),
       resp_body: nil
+    )
+  end
+
+  @doc false
+  def upgrade_to_websocket(handler, init, connection(state: state) = conn)
+      when state in [:unset, :set] do
+    connection(conn,
+      websocket_handler: handler,
+      websocket_init: init,
+      resp_body: nil,
+      state: :sent
     )
   end
 
@@ -287,6 +299,20 @@ defmodule Dynamo.Connection.Test do
   """
   def fetched(connection(fetched: fetched)) do
     fetched
+  end
+
+  @doc """
+  Returns websocket handler possibly set during a request.
+  """
+  def websocket_handler(connection(websocket_handler: websocket_handler)) do
+    websocket_handler
+  end
+
+  @doc """
+  Returns websocket init possibly set during a request.
+  """
+  def websocket_init(connection(websocket_init: websocket_init)) do
+    websocket_init
   end
 
   @doc """

--- a/lib/dynamo/cowboy/connection.ex
+++ b/lib/dynamo/cowboy/connection.ex
@@ -168,6 +168,19 @@ defmodule Dynamo.Cowboy.Connection do
     )
   end
 
+  @doc false
+  def upgrade_to_websocket(handler, init, connection(state: state) = conn)
+      when state in [:unset, :set] do
+    connection(req: req) = conn
+    req = R.set_meta(:websocket_init, init, req)
+    req = R.set_meta(:websocket_handler, handler, req)
+    connection(conn,
+      req: req,
+      resp_body: nil,
+      state: :sent
+    )
+  end
+
   ## Misc
 
   @doc false

--- a/lib/dynamo/cowboy/handler.ex
+++ b/lib/dynamo/cowboy/handler.ex
@@ -14,10 +14,15 @@ defmodule Dynamo.Cowboy.Handler do
   def init({ transport, :http }, req, main) when transport in [:tcp, :ssl] do
     conn = main.service(Dynamo.Cowboy.Connection.new(main, req, scheme(transport)))
 
-    if is_record(conn, Dynamo.Cowboy.Connection) do
-      { :ok, conn.cowboy_request, nil }
-    else
-      raise "Expected service to return a Dynamo.Cowboy.Connection, got #{inspect conn}"
+    { websocket_init, _req } = R.meta(:websocket_init, conn.cowboy_request)
+    cond do
+      websocket_init != :undefined ->
+        req = R.set_meta(:websocket_init, nil, conn.cowboy_request)
+        { :upgrade, :protocol, :cowboy_websocket, req, websocket_init }
+      is_record(conn, Dynamo.Cowboy.Connection) ->
+        { :ok, conn.cowboy_request, nil }
+      true ->
+        raise "Expected service to return a Dynamo.Cowboy.Connection, got #{inspect conn}"
     end
   end
 
@@ -31,23 +36,23 @@ defmodule Dynamo.Cowboy.Handler do
 
   # Websockets
 
-  def websocket_init(any, req, conn) do
-    { mod, req } = req.meta(:websocket_handler)
-    mod.websocket_init(any, req, conn)
+  def websocket_init(any, req, init) do
+    { mod, req } = R.meta(:websocket_handler, req)
+    mod.websocket_init(any, req, init)
   end
 
   def websocket_handle(msg, req, state) do
-    { mod, req } = req.meta(:websocket_handler)
+    { mod, req } = R.meta(:websocket_handler, req)
     mod.websocket_handle(msg, req, state)
   end
 
   def websocket_info(msg, req, state) do
-    { mod, req } = req.meta(:websocket_handler)
+    { mod, req } = R.meta(:websocket_handler, req)
     mod.websocket_info(msg, req, state)
   end
 
   def websocket_terminate(reason, req, state) do
-    { mod, req } = req.meta(:websocket_handler)
+    { mod, req } = R.meta(:websocket_handler, req)
     mod.websocket_terminate(reason, req, state)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -22,6 +22,7 @@ defmodule Dynamo.Mixfile do
   def deps(_) do
     deps(:prod) ++
       [ { :hackney, github: "benoitc/hackney" },
+        { :websocket_client, github: "jeremyong/websocket_client" },
         { :cowboy,  github: "extend/cowboy" } ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 [ "cowboy": {:git, "git://github.com/extend/cowboy.git", "bbee34fe1638b742796b00b39c0859395a752167", []},
   "hackney": {:git, "git://github.com/benoitc/hackney.git", "5b0f7eb949ebebd6fabfbc4e08a7b7231850606a", []},
   "mimetypes": {:git, "git://github.com/spawngrid/mimetypes.git", "47d37a977a7d633199822bf6b08353007483d00f", []},
-  "ranch": {:git, "git://github.com/extend/ranch.git", "41705752ffc7e3ecb96eef8374015ead4ca7f699", [{:ref, "0.8.5"}]} ]
+  "ranch": {:git, "git://github.com/extend/ranch.git", "41705752ffc7e3ecb96eef8374015ead4ca7f699", [{:ref, "0.8.5"}]},
+  "websocket_client": {:git, "git://github.com/jeremyong/websocket_client.git", "7b8731ab0aa6070fb78e29750380f89cf529627a", []} ]

--- a/test/dynamo/cowboy/websocket_test.exs
+++ b/test/dynamo/cowboy/websocket_test.exs
@@ -1,0 +1,119 @@
+defmodule Dynamo.Cowboy.WebsocketTest do
+  use ExUnit.Case
+
+  defmodule WebsocketHandler1 do
+    @behaviour :cowboy_websocket_handler
+    def websocket_init(_transport_name, req, _opts), do: { :ok, req, :undefined_state }
+    def websocket_handle(_data, req, state), do: { :ok, req, state}
+    def websocket_info(_data, req, state), do: { :ok, req, state }
+    def websocket_terminate(_reason, _req, _state), do: :ok
+  end
+
+  defmodule WebsocketHandler2 do
+    @behaviour :cowboy_websocket_handler
+    def websocket_init(_transport_name, req, state) do
+      conn = Keyword.get(state, :conn)
+      init = Keyword.get(state, :init)
+      cond do
+        conn.params[:nick] ->
+          self <- { :send_text, "room=#{conn.params[:room]}-nick=#{conn.params[:nick]}" }
+        init ->
+          self <- { :send_text, "init=#{inspect init}" }
+        true ->
+      end
+      { :ok, req, :undefined_state }
+    end
+    def websocket_info({ :send_text, message }, req, state) do
+      { :reply, { :text, message }, req, state }
+    end
+    def websocket_info(_data, req, state), do: { :ok, req, state }
+    def websocket_handle( { :text, message }, req, state) do
+      { :reply, {:text, "server: #{message}" }, req, state }
+    end
+    def websocket_handle(_data, req, state), do: { :ok, req, state}
+    def websocket_terminate(_reason, _req, _state), do: :ok
+  end
+
+  defmodule ApplicationRouter do
+    use Dynamo.Router
+
+    prepare do: conn.fetch(:params)
+
+    websocket "/ws/:room", using: WebsocketHandler2
+    websocket "/ws", using: WebsocketHandler1
+
+    get "/wsinit" do
+      conn.upgrade_to_websocket WebsocketHandler2, [ conn: conn, init: { :initial, 'state' } ]
+    end
+  end
+
+  defmodule WebsocketClient do
+    @behaviour :websocket_client_handler
+    def start_link(url, pid), do: :websocket_client.start_link(url, __MODULE__, [pid])
+    def init([pid], _conn_state) do
+      pid <- { :ws_initialized, :ok }
+      { :ok, pid }
+    end
+    def websocket_handle({ :text, message }, _conn_state, pid) do
+      pid <- { :ws_text_received, message }
+      { :ok, pid }
+    end
+    def websocket_handle(_data, _conn_state, state), do: { :ok, state }
+    def websocket_info({ :send_text, message }, _conn_state, pid) do
+      { :reply, { :text, message }, pid }
+    end
+    def websocket_info(_data, _conn_state, state), do: { :ok, state }
+    def websocket_terminate(_reason, _conn_state, _state), do: :ok
+  end
+
+  setup_all do
+    Dynamo.Cowboy.run ApplicationRouter, port: 8011, verbose: false
+    :ok
+  end
+
+  teardown_all do
+    Dynamo.Cowboy.shutdown ApplicationRouter
+    :ok
+  end
+
+  test "websocket clients can connect" do
+    WebsocketClient.start_link('ws://127.0.0.1:8011/ws', self)
+    wait_for(:ws_initialized, "client was not initialized as expected")
+  end
+
+  test "on init the websocket server can access params" do
+    WebsocketClient.start_link('ws://127.0.0.1:8011/ws/42?nick=zorn', self)
+    wait_for(:ws_initialized)
+    message = wait_for(:ws_text_received, "client did not receive params message")
+    assert message == "room=42-nick=zorn"
+  end
+
+  test "on init the websocket server can access initial state set by router" do
+    WebsocketClient.start_link('ws://127.0.0.1:8011/wsinit', self)
+    wait_for(:ws_initialized)
+    message = wait_for(:ws_text_received, "client did not receive initial state message")
+    assert message == "init={:initial, 'state'}"
+  end
+
+  test "websocket clients can send a text message" do
+    { :ok, client } = WebsocketClient.start_link('ws://127.0.0.1:8011/ws/123', self)
+    wait_for(:ws_initialized)
+    client <- { :send_text, "hello there" }
+    message = wait_for(:ws_text_received, "client did not receive message sent")
+    assert message == "server: hello there"
+  end
+
+  defp wait_for(expected, error // "message was not received as expected") do
+    receive do
+      { message, data } ->
+        if message == expected do
+          assert true
+          data
+        else
+          assert false, error
+        end
+    after
+      500 -> assert false, error
+    end
+  end
+end

--- a/test/dynamo/router/base_test.exs
+++ b/test/dynamo/router/base_test.exs
@@ -61,11 +61,14 @@ defmodule Dynamo.Router.BaseTest do
     end
   end
 
+
   defmodule RootSample do
     use Dynamo.Router
 
     prepare do: conn.fetch(:params)
 
+    defmodule WebsocketHandler1 do; end
+    websocket "/ws/:web", using: WebsocketHandler1
     forward "/", to: Sample1
   end
 
@@ -173,5 +176,12 @@ defmodule Dynamo.Router.BaseTest do
     assert conn.assigns[:value] == :root
     assert conn.route_params[:var] == "hello"
     assert conn.params[:var] == "hello"
+  end
+
+  test "forwarding to a websocket handler" do
+    conn = get("/ws/socket")
+    assert conn.websocket_handler == RootSample.WebsocketHandler1
+    init_conn = Keyword.get(conn.websocket_init, :conn)
+    assert init_conn.params[:web] == "socket"
   end
 end


### PR DESCRIPTION
The goal of this pull request is to give a shot at offering basic support for websockets, allowing to forward websocket requests to Cowboy websocket handlers.

It adds an `upgrade_to_websocket` function to connections to specify the handler module and the initial state to pass to `websocket_init`.

It also adds a `websocket` macro to the router DSL for a 1 line routing declaration.

Here is an example on how I use it [to interface with a pubsub server](https://gist.github.com/mathieul/6459540).

This is just a first draft to figure out if that's a direction you're interested in for the websocket support. Let me know what you think, thanks.
