### PR TITLE
Remove websocket behavior from cowboy handler and add websocket example

### DIFF
--- a/examples/websocket.exs
+++ b/examples/websocket.exs
@@ -1,0 +1,66 @@
+# Run this app from Dynamo root with:
+#
+#     mix run -r examples/websocket.exs --no-halt
+#
+# Cowboy Websocket Handler resources:
+#
+#   * User guide: http://ninenines.eu/docs/en/cowboy/HEAD/guide/ws_handlers
+#   * Reference:  http://ninenines.eu/docs/en/cowboy/HEAD/manual/cowboy_websocket_handler
+#
+defmodule Websocket do
+  defmodule Teller do
+    def start, do: :global.register_name(:teller, spawn(__MODULE__, :listen, []))
+    def server, do: :global.whereis_name(:teller)
+    def register(pid), do: server <- { :register, pid }
+    def tell(message), do: server <- { :tell, message }
+    def listen(registrees // []) do
+      receive do
+        { :register, pid } -> listen([ pid | registrees ])
+        { :tell, message } ->
+          Enum.each registrees, fn pid ->
+            pid <- { :message, message }
+          end
+          listen(registrees)
+      end
+    end
+  end
+
+  defmodule WebsocketHandler do
+    @behaviour :cowboy_websocket_handler
+    def init({:tcp, :http}, _req, _opts), do: { :upgrade, :protocol, :cowboy_websocket }
+    def websocket_init(_transport_name, req, _opts) do
+      Teller.register(self)
+      { :ok, req, :no_state }
+    end
+    def websocket_handle( { :text, message }, req, state) do
+      { :reply, {:text, message }, req, state }
+    end
+    def websocket_info({ :message, message }, req, state) do
+      { :reply, { :text, message }, req, state }
+    end
+    def websocket_terminate(_reason, _req, _state), do: :ok
+  end
+
+  defmodule Router do
+    use Dynamo
+    use Dynamo.Router
+
+    config :dynamo, compile_on_demand: false
+    config :server,
+      port: 3030,
+      dispatch: [{ :_, [
+        {"/websocket", WebsocketHandler, [] },
+        {:_, Dynamo.Cowboy.Handler, __MODULE__ }
+      ] }]
+
+    get "/*segments" do
+      message = Enum.join(conn.route_params[:segments], " ")
+      Teller.tell(message)
+      conn.resp_body("message sent: #{message}")
+    end
+  end
+end
+
+Websocket.Teller.start
+Websocket.Router.start_link
+Websocket.Router.run

--- a/examples/websocket.exs
+++ b/examples/websocket.exs
@@ -2,40 +2,25 @@
 #
 #     mix run -r examples/websocket.exs --no-halt
 #
-# Cowboy Websocket Handler resources:
-#
-#   * User guide: http://ninenines.eu/docs/en/cowboy/HEAD/guide/ws_handlers
-#   * Reference:  http://ninenines.eu/docs/en/cowboy/HEAD/manual/cowboy_websocket_handler
+# Open a browser supporting websockets at URL http://localhost:3030 and wait for 3 seconds.
 #
 defmodule Websocket do
-  defmodule Teller do
-    def start, do: :global.register_name(:teller, spawn(__MODULE__, :listen, []))
-    def server, do: :global.whereis_name(:teller)
-    def register(pid), do: server <- { :register, pid }
-    def tell(message), do: server <- { :tell, message }
-    def listen(registrees // []) do
-      receive do
-        { :register, pid } -> listen([ pid | registrees ])
-        { :tell, message } ->
-          Enum.each registrees, fn pid ->
-            pid <- { :message, message }
-          end
-          listen(registrees)
-      end
-    end
-  end
-
-  defmodule WebsocketHandler do
+  # Cowboy Websocket Handler resources:
+  #
+  #   * User guide: http://ninenines.eu/docs/en/cowboy/HEAD/guide/ws_handlers
+  #   * Reference:  http://ninenines.eu/docs/en/cowboy/HEAD/manual/cowboy_websocket_handler
+  #
+  defmodule Handler do
     @behaviour :cowboy_websocket_handler
     def init({:tcp, :http}, _req, _opts), do: { :upgrade, :protocol, :cowboy_websocket }
     def websocket_init(_transport_name, req, _opts) do
-      Teller.register(self)
+      :timer.send_interval(3000, { :message, "Are we there yet?" })
       { :ok, req, :no_state }
     end
-    def websocket_handle( { :text, message }, req, state) do
-      { :reply, {:text, message }, req, state }
-    end
     def websocket_info({ :message, message }, req, state) do
+      { :reply, { :text, message }, req, state }
+    end
+    def websocket_handle({ :text, message }, req, state) do
       { :reply, { :text, message }, req, state }
     end
     def websocket_terminate(_reason, _req, _state), do: :ok
@@ -45,22 +30,19 @@ defmodule Websocket do
     use Dynamo
     use Dynamo.Router
 
-    config :dynamo, compile_on_demand: false
+    config :dynamo, templates_paths: [ Path.expand("../websocket", __FILE__) ]
     config :server,
       port: 3030,
       dispatch: [{ :_, [
-        {"/websocket", WebsocketHandler, [] },
+        {"/websocket", Handler, [] },
         {:_, Dynamo.Cowboy.Handler, __MODULE__ }
       ] }]
 
-    get "/*segments" do
-      message = Enum.join(conn.route_params[:segments], " ")
-      Teller.tell(message)
-      conn.resp_body("message sent: #{message}")
+    get "/" do
+      render conn, "index.html"
     end
   end
 end
 
-Websocket.Teller.start
 Websocket.Router.start_link
 Websocket.Router.run

--- a/examples/websocket/index.html.eex
+++ b/examples/websocket/index.html.eex
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <title>Websocket Example</title>
+</head>
+<body>
+  <h2>Incoming messages:</h2>
+  <div id="messages"></div>
+  <script>
+    (function () {
+      var messages = document.getElementById("messages"),
+          ws = new WebSocket("ws://localhost:3030/websocket");
+
+      ws.onmessage = function (event) {
+        messages.innerHTML += "<p>" + event.data + "</p>";
+      };
+    })();
+  </script>
+</body>
+</html>

--- a/lib/dynamo/cowboy/handler.ex
+++ b/lib/dynamo/cowboy/handler.ex
@@ -2,7 +2,6 @@ defmodule Dynamo.Cowboy.Handler do
   @moduledoc false
 
   @behaviour :cowboy_http_handler
-  @behaviour :cowboy_websocket_handler
 
   require :cowboy_req, as: R
 
@@ -27,27 +26,5 @@ defmodule Dynamo.Cowboy.Handler do
 
   def terminate(_reason, _req, nil) do
     :ok
-  end
-
-  # Websockets
-
-  def websocket_init(any, req, conn) do
-    { mod, req } = req.meta(:websocket_handler)
-    mod.websocket_init(any, req, conn)
-  end
-
-  def websocket_handle(msg, req, state) do
-    { mod, req } = req.meta(:websocket_handler)
-    mod.websocket_handle(msg, req, state)
-  end
-
-  def websocket_info(msg, req, state) do
-    { mod, req } = req.meta(:websocket_handler)
-    mod.websocket_info(msg, req, state)
-  end
-
-  def websocket_terminate(reason, req, state) do
-    { mod, req } = req.meta(:websocket_handler)
-    mod.websocket_terminate(reason, req, state)
   end
 end


### PR DESCRIPTION
When I saw that `Dynamo.Cowboy.Handler` was using the cowboy websocket handler behavior I believed the intent was to have it handle websocket connections. If that's not the case anymore we can probably remove it.

I also added an example of using the server `:dispatch` config option to interface with a cowboy handler.

Feel free to discard if it's not helpful, cheers.
