### PR TITLE
Dynamo.Filters.MethodOverride

### DIFF
--- a/lib/dynamo/filters/methodoverride.ex
+++ b/lib/dynamo/filters/methodoverride.ex
@@ -1,0 +1,18 @@
+defmodule Dynamo.Filters.MethodOverride do
+  @moduledoc """
+  A filter to overwrite "POST" method with the one defined in _method parameter.
+  """
+  def service(conn, fun) do
+    if conn.method == "POST" do
+      conn = conn.fetch(:params)
+      case Dict.get(conn.params, :_method) do
+        "DELETE" -> fun.(conn.method("DELETE"))
+        "PUT"    -> fun.(conn.method("PUT"))
+        "PATCH"  -> fun.(conn.method("PATCH"))
+        _        -> fun.(conn)
+      end
+    else
+      fun.(conn)
+    end
+  end
+end

--- a/test/dynamo/filters/methodoverride_test.exs
+++ b/test/dynamo/filters/methodoverride_test.exs
@@ -1,0 +1,42 @@
+defmodule Dynamo.Filters.MethodOverrideTest do
+  defmodule MethodOverrideApp do
+    use Dynamo.Router
+
+    filter Dynamo.Filters.MethodOverride
+
+    delete "/hello" do
+      conn.send(200, "DELETE")
+    end
+
+    put "/hello" do
+      conn.send(200, "PUT")
+    end
+
+    patch "/hello" do
+      conn.send(200, "PATCH")
+    end
+  end
+
+  use ExUnit.Case, async: true
+  use Dynamo.HTTP.Case
+
+  @endpoint MethodOverrideApp
+
+  test "converts POST to DELETE when _method=DELETE param is specified" do
+    conn = process @endpoint, :POST, "/hello?_method=DELETE"
+    assert conn.status == 200
+    assert conn.sent_body == "DELETE"
+  end
+
+  test "converts POST to PUT when _method=PUT param is specified" do
+    conn = process @endpoint, :POST, "/hello?_method=PUT"
+    assert conn.status == 200
+    assert conn.sent_body == "PUT"
+  end
+
+  test "converts POST to PATCH when _method=PATCH param is specified" do
+    conn = process @endpoint, :POST, "/hello?_method=PATCH"
+    assert conn.status == 200
+    assert conn.sent_body == "PATCH"
+  end
+end


### PR DESCRIPTION
Hi. How do you think about having Rack::MethodOverride kind of feature, like the Sinatra's :method_override?

http://www.sinatrarb.com/configuration.html

> :method_override - enable/disable the POST _method hack

I was playing around REST-based object manipulation, and needed to write a filter for using PUT/DELETE methods for HTML form submits.
- https://gist.github.com/parroty/6651311
- https://github.com/parroty/dynamo_scaffold

As it may be relatively common scenario, I'm wondering if it could be included as optional feature (enable by - filter Dynamo.Filters.MethodOverride, or something).
