### PR TITLE
skip mix dynamo.filters if Mix.project[:dynamos] is not defined

### DIFF
--- a/lib/mix/tasks/dynamo.filters.ex
+++ b/lib/mix/tasks/dynamo.filters.ex
@@ -11,7 +11,7 @@ defmodule Mix.Tasks.Dynamo.Filters do
     Mix.Task.run "app.start", args
     shell = Mix.shell
 
-    Enum.each Mix.project[:dynamos], fn(dynamo) ->
+    Enum.each (Mix.project[:dynamos] || []), fn(dynamo) ->
       shell.info "# #{inspect dynamo}"
 
       Enum.each dynamo.__filters__, fn(filter) ->


### PR DESCRIPTION
"mix dynamo.filters" on original dynamo project fails with the "Protocol.UndefinedError". 
It would not be a valid scenario (it should be executed for a project created by "mix dynamo"), but it's nice to just skip the task processing if there's nothing to be displayed?

% git clone https://github.com/elixir-lang/dynamo
% cd dynamo
% mix deps.get
% mix compile
% mix dynamo.filters
*\* (Protocol.UndefinedError) protocol Enumerable not implemented for nil
    /Users/knakase/tmp/github/elixir/lib/elixir/lib/enum.ex:1: Enumerable.impl_for!/1
    /Users/knakase/tmp/github/elixir/lib/elixir/lib/enum.ex:37: Enumerable.reduce/3
    /Users/knakase/tmp/github/elixir/lib/elixir/lib/enum.ex:354: Enum.each/2
    /Users/knakase/tmp/github/elixir/lib/mix/lib/mix/project.ex:153: Mix.Project.recur/2
    /Users/knakase/tmp/github/elixir/lib/mix/lib/mix/task.ex:167: Mix.Task.run/2
    /Users/knakase/tmp/github/elixir/lib/mix/lib/mix/cli.ex:61: Mix.CLI.run_task/2
