### PR TITLE
Stop checking if the ETS table exists in the ETSStore

### DIFF
--- a/lib/dynamo/filters/session/stores.ex
+++ b/lib/dynamo/filters/session/stores.ex
@@ -99,16 +99,11 @@ defmodule Session.ETSStore do
   @behaviour Session.Store
 
   def setup(opts) do
-    if table = opts[:table] do
-      if :ets.info(table, :name) == :undefined do
-        raise ArgumentError, message: "ETSStore expects an exitsting public table, " <>
-          "table #{inspect table} not found"
-      end
-
-      opts
-    else
+    if nil?(opts[:table]) do
       raise ArgumentError, message: "ETSStore expects a table as option"
     end
+
+    opts
   end
 
   def get_session(content, opts) do


### PR DESCRIPTION
This is impossible to know in any other scenario but putting the
filter in your router during development.
