### PR TITLE
Updating binary_to_atom deprecation

### DIFF
--- a/test/dynamo/cowboy/connection_test.exs
+++ b/test/dynamo/cowboy/connection_test.exs
@@ -12,7 +12,7 @@ defmodule Dynamo.Cowboy.ConnectionTest do
   end
 
   def service(conn) do
-    function = binary_to_atom hd(conn.path_segments), :utf8
+    function = binary_to_atom hd(conn.path_segments)
     apply __MODULE__, function, [conn]
   rescue
     exception ->


### PR DESCRIPTION
Think this should be safe to do in all elixir versions.
