### PR TITLE
Update generated .gitignore to use _build

### DIFF
--- a/lib/mix/tasks/dynamo.ex
+++ b/lib/mix/tasks/dynamo.ex
@@ -122,10 +122,9 @@ defmodule Mix.Tasks.Dynamo do
   """
 
   embed_text :gitignore, """
-  /ebin
+  /_build
   /deps
-  /tmp/dev
-  /tmp/test
+  /tmp
   erl_crash.dump
   """
 


### PR DESCRIPTION
New dynamo projects are still generating gitignores w/ ebin instead of _build. I just switched up the gitignore template to match dynamo's own.
