### PR TITLE
Enables the connection.send/3 to respond custom http error codes using binary strings.

### DIFF
--- a/lib/dynamo/cowboy/connection.ex
+++ b/lib/dynamo/cowboy/connection.ex
@@ -112,8 +112,7 @@ defmodule Dynamo.Cowboy.Connection do
   end
 
   @doc false
-  def send(status, body, connection(state: state) = conn) when is_integer(status)
-      and state in [:unset, :set] and is_binary(body) do
+  def send(status, body, connection(state: state) = conn) when state in [:unset, :set] and is_binary(body) do
     conn = run_before_send(connection(conn, status: status, resp_body: body, state: :set))
     connection(req: req, status: status, resp_body: body,
                resp_headers: headers, resp_cookies: cookies) = conn


### PR DESCRIPTION
Hello guys!

I was working on a custom project where is needed to return custom http error codes, the problem is that the guard does not allow to pass a binary string as the status parameter, even if cowboy supports it.

``` elixir
# Typical method
conn.send 404, "Wrong page bud"

# Custom http response code
conn.send "499 Wrong page bud", "Another thing"
```

If this a no go,  no explanation is required or asked for.

Thanks!
