### PR TITLE
Fix typo on module attribute

### DIFF
--- a/lib/dynamo/templates/renderer.ex
+++ b/lib/dynamo/templates/renderer.ex
@@ -82,7 +82,7 @@ defmodule Dynamo.Templates.Renderer do
   end
 
   defp raise_too_busy(Template[identifier: identifier]) do
-    raise "Compiling template #{inspect identifier} exceeded the max number of attempts #{@max_attemps}. What gives?"
+    raise "Compiling template #{inspect identifier} exceeded the max number of attempts #{@max_attempts}. What gives?"
   end
 
   ## Backend
@@ -137,7 +137,7 @@ defmodule Dynamo.Templates.Renderer do
     :code.purge(module)
   end
 
-  defp generate_suggestion(name, attempts) when attempts < @max_attemps do
+  defp generate_suggestion(name, attempts) when attempts < @max_attempts do
     random = :random.uniform(@slots)
     module = Module.concat(name, "T#{random}")
 


### PR DESCRIPTION
Fix typo in @max_attempts in Dynamo.Templates.Renderer. 
Also, it seems causing the following warning at compile.

```
Compiled lib/dynamo/utils/message_verifier.ex
nofile:0:  undefined module attribute @max_attemps, please remove access to @max_attemps or explicitly set it to nil before access
Compiled lib/dynamo/utils/once.ex
nofile:0:  undefined module attribute @max_attemps, please remove access to @max_attemps or explicitly set it to nil before access
```

it's defined as

```
defmodule Dynamo.Templates.Renderer do
  @moduledoc false
  @slots 1_000_000
  @max_attempts 1_000
```
