### PR TITLE
Make post(path, body) work in tests

### DIFF
--- a/lib/dynamo/http/case.ex
+++ b/lib/dynamo/http/case.ex
@@ -197,6 +197,10 @@ defmodule Dynamo.HTTP.Case do
     do_process endpoint, Dynamo.Connection.Test.new(method, path)
   end
 
+  def process(endpoint, path, method, body) when is_binary(path) do
+    do_process endpoint, conn(method, path, body)
+  end
+
   defp do_process(endpoint, conn) do
     conn = endpoint.service(conn)
 

--- a/test/dynamo/http/case_test.exs
+++ b/test/dynamo/http/case_test.exs
@@ -15,6 +15,11 @@ defmodule Dynamo.HTTP.CaseTest do
     get "/get_session" do
       conn.send(200, get_session(conn, :hello))
     end
+
+    post "/test_post" do
+      conn = conn.fetch :body
+      conn.send 200, conn.req_body
+    end
   end
 
   use ExUnit.Case
@@ -36,5 +41,10 @@ defmodule Dynamo.HTTP.CaseTest do
     conn = put_session_cookie conn(:get, "/"), hello: "world"
     conn = get(conn, "/get_session")
     assert conn.sent_body == "world"
+  end
+
+  test "sees the request body from a post" do
+    conn = post("/test_post", "test body")
+    assert conn.sent_body == "test body"
   end
 end


### PR DESCRIPTION
Not entirely happy with the solution as it could be tricky to notice the
args have changed order in the future but the is_binary test helps with
that
