### PR TITLE
__FILE__ is deprecated, we should use __DIR__ or __ENV__.file instead

### DIFF
--- a/lib/dynamo/filters/exceptions/debug.ex
+++ b/lib/dynamo/filters/exceptions/debug.ex
@@ -149,5 +149,5 @@ defmodule Dynamo.Filters.Exceptions.Debug do
   require EEx
 
   EEx.function_from_file :defp, :template,
-    Path.expand("../template.eex", __FILE__), [:conn, :assigns]
+    Path.expand("template.eex", __DIR__), [:conn, :assigns]
 end

--- a/lib/mix/tasks/dynamo.ex
+++ b/lib/mix/tasks/dynamo.ex
@@ -53,7 +53,7 @@ defmodule Mix.Tasks.Dynamo do
     lib = underscore(mod)
 
     dynamo = if opts[:dev] do
-      %s(path: "#{Path.expand("../../../..", __FILE__)}")
+      %s(path: "#{Path.expand("../../..", __DIR__)}")
     else
       %s(github: "elixir-lang/dynamo")
     end

--- a/test/dynamo/connection/test_test.exs
+++ b/test/dynamo/connection/test_test.exs
@@ -186,7 +186,7 @@ defmodule Dynamo.Connection.TestTest do
   end
 
   test :sendfile do
-    file = Path.expand("../../../fixtures/static/file.txt", __FILE__)
+    file = Path.expand("../../fixtures/static/file.txt", __DIR__)
     conn = conn(:GET, "/").sendfile(200, file)
     assert conn.state     == :sent
     assert conn.status    == 200

--- a/test/dynamo/cowboy/connection_test.exs
+++ b/test/dynamo/cowboy/connection_test.exs
@@ -358,7 +358,7 @@ defmodule Dynamo.Cowboy.ConnectionTest do
   end
 
   def sendfile(conn) do
-    file = Path.expand("../../../fixtures/static/file.txt", __FILE__)
+    file = Path.expand("../../fixtures/static/file.txt", __DIR__)
     conn = conn.sendfile(200, file)
     assert conn.state  == :sent
     assert conn.status == 200
@@ -390,7 +390,7 @@ defmodule Dynamo.Cowboy.ConnectionTest do
   end
 
   def before_send_with_sendfile(conn) do
-    file = Path.expand("../../../fixtures/static/file.txt", __FILE__)
+    file = Path.expand("../../fixtures/static/file.txt", __DIR__)
     conn.before_send(fn(conn) ->
       assert conn.state == :sendfile
       assert conn.status == 201

--- a/test/dynamo/cowboy/ssl_test.exs
+++ b/test/dynamo/cowboy/ssl_test.exs
@@ -26,8 +26,8 @@ defmodule Dynamo.Cowboy.SSLTest do
     config :ssl,
       port: 8022,
       password: "cowboy",
-      keyfile: Path.expand("../../../fixtures/ssl/key.pem", __FILE__),
-      certfile: Path.expand("../../../fixtures/ssl/cert.pem", __FILE__)
+      keyfile: Path.expand("../../fixtures/ssl/key.pem", __DIR__),
+      certfile: Path.expand("../../fixtures/ssl/cert.pem", __DIR__)
   end
 
   setup_all do

--- a/test/dynamo/filters/exceptions/debug_test.exs
+++ b/test/dynamo/filters/exceptions/debug_test.exs
@@ -6,7 +6,7 @@ defmodule Dynamo.Filters.Exceptions.DebugTest do
     config :dynamo,
       source_paths: ["filters/exceptions"],
       exceptions_editor: "editor://__FILE__:__LINE__",
-      root: Path.expand("../../..", __FILE__) # test/dynamo
+      root: Path.expand("../..", __DIR__) # test/dynamo
   end
 
   use ExUnit.Case, async: true
@@ -35,7 +35,7 @@ defmodule Dynamo.Filters.Exceptions.DebugTest do
 
   test "show editor links" do
     conn = @endpoint.service(conn)
-    assert conn.sent_body =~ %r"editor://#{URI.encode __FILE__}:#{16}"
+    assert conn.sent_body =~ %r"editor://#{URI.encode __ENV__.file}:#{16}"
   end
 
   test "shows snippets if they are part of the source_paths" do

--- a/test/dynamo/filters/exceptions_test.exs
+++ b/test/dynamo/filters/exceptions_test.exs
@@ -13,7 +13,7 @@ defmodule Dynamo.Filters.ExceptionsTest do
     filter Dynamo.Filters.Exceptions.new(Dynamo.Filters.Exceptions.Public)
 
     def root do
-      __FILE__
+      __ENV__.file
     end
 
     # Halt

--- a/test/dynamo/filters/static_test.exs
+++ b/test/dynamo/filters/static_test.exs
@@ -3,7 +3,7 @@ defmodule Dynamo.Filters.StaticTest do
     use Dynamo
     use Dynamo.Router
 
-    config :dynamo, root: Path.expand("../../..", __FILE__)
+    config :dynamo, root: Path.expand("../..", __DIR__)
 
     filter Dynamo.Filters.Static.new("/public", "")
 

--- a/test/dynamo/http/render_test.exs
+++ b/test/dynamo/http/render_test.exs
@@ -24,7 +24,7 @@ defmodule Dynamo.HTTP.RenderTest do
 
     config :dynamo,
       endpoint: RenderingRouter,
-      templates_paths: [Path.expand("../../../fixtures/templates", __FILE__)]
+      templates_paths: [Path.expand("../../fixtures/templates", __DIR__)]
 
     templates do
       import List, only: [flatten: 1], warn: false

--- a/test/dynamo/reloader_test.exs
+++ b/test/dynamo/reloader_test.exs
@@ -2,7 +2,7 @@ defmodule Dynamo.LoaderTest do
   use ExUnit.Case
 
   defp fixture_path do
-    Path.expand("../../fixtures/reloader", __FILE__)
+    Path.expand("../fixtures/reloader", __DIR__)
   end
 
   setup_all do

--- a/test/dynamo/templates/finder_test.exs
+++ b/test/dynamo/templates/finder_test.exs
@@ -1,7 +1,7 @@
 defmodule Dynamo.Templates.FinderTest do
   use ExUnit.Case, async: true
 
-  @fixture_path Path.expand("../../../fixtures/templates", __FILE__)
+  @fixture_path Path.expand("../../fixtures/templates", __DIR__)
 
   test "finds available template" do
     path = Path.join(@fixture_path, "hello.html.eex")

--- a/test/dynamo/templates_test.exs
+++ b/test/dynamo/templates_test.exs
@@ -2,7 +2,7 @@ defmodule Dynamo.TemplatesTest do
   use ExUnit.Case, async: true
 
   @renderer __MODULE__.Renderer
-  @fixture_path Path.expand("../../fixtures/templates", __FILE__)
+  @fixture_path Path.expand("../fixtures/templates", __DIR__)
 
   setup_all do
     Dynamo.Templates.Renderer.start_link(@renderer)
@@ -35,7 +35,7 @@ defmodule Dynamo.TemplatesTest do
     cached = render "module.html"
     assert module == cached
 
-    template = Path.expand("../../fixtures/templates/module.html.eex", __FILE__)
+    template = Path.expand("../fixtures/templates/module.html.eex", __DIR__)
 
     try do
       File.touch!(template, { { 2030, 1, 1 }, { 0, 0, 0 } })

--- a/test/dynamo_test.exs
+++ b/test/dynamo_test.exs
@@ -5,14 +5,14 @@ defmodule DynamoTest do
     use Dynamo
 
     config :dynamo,
-      root: Path.expand("../fixtures", __FILE__),
+      root: Path.expand("fixtures", __DIR__),
       endpoint: DynamoTest,
-      static_root: Path.expand("../fixtures/public", __FILE__),
+      static_root: Path.expand("fixtures/public", __DIR__),
       static_route: "/public",
       compile_on_demand: false,
       reload_modules: false,
-      source_paths: [Path.expand("../fixtures/*", __FILE__)],
-      templates_paths: [Path.expand("../fixtures/templates", __FILE__)]
+      source_paths: [Path.expand("fixtures/*", __DIR__)],
+      templates_paths: [Path.expand("fixtures/templates", __DIR__)]
 
     # Test session compilation as well
     config :dynamo,
@@ -41,13 +41,13 @@ defmodule DynamoTest do
   end
 
   test "defines root based on user config" do
-    assert App.root == Path.expand("../fixtures", __FILE__)
+    assert App.root == Path.expand("fixtures", __DIR__)
   end
 
   ## Filters
 
   test "adds public filter" do
-    file = Path.expand("../fixtures/public", __FILE__)
+    file = Path.expand("fixtures/public", __DIR__)
     assert Enum.first(App.__filters__) == Dynamo.Filters.Static.new("/public", file)
   end
 
@@ -67,7 +67,7 @@ defmodule DynamoTest do
 
   test "defines templates paths" do
     assert App.templates_paths == [DynamoTest.App.CompiledTemplates]
-    templates = Path.expand("../fixtures/templates", __FILE__)
+    templates = Path.expand("fixtures/templates", __DIR__)
     assert ReloadApp.templates_paths == [templates]
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -14,7 +14,7 @@ defmodule MixHelpers do
   import ExUnit.Assertions
 
   def tmp_path do
-    Path.expand("../../tmp", __FILE__)
+    Path.expand("../tmp", __DIR__)
   end
 
   def tmp_path(extension) do


### PR DESCRIPTION
This replaces all occurrences of **FILE** in the code to avoid this warning message:

`__FILE__ is deprecated, please use __DIR__ or __ENV__.file instead`
