### PR TITLE
Remove deprecated Kernel term_to_binary/binary_to_term

### DIFF
--- a/lib/dynamo/utils/message_verifier.ex
+++ b/lib/dynamo/utils/message_verifier.ex
@@ -15,7 +15,7 @@ defmodule Dynamo.Utils.MessageVerifier do
     case :binary.split(encoded, "--") do
       [content, digest] when content != "" and digest != "" ->
         if secure_compare(digest(secret, content), digest) do
-          { :ok, content |> :base64.decode |> binary_to_term }
+          { :ok, content |> :base64.decode |> :erlang.binary_to_term }
         else
           :error
         end
@@ -28,7 +28,7 @@ defmodule Dynamo.Utils.MessageVerifier do
   Generates an encoded and signed binary for the given term.
   """
   def generate(secret, term) do
-    encoded = term |> term_to_binary |> :base64.encode
+    encoded = term |> :erlang.term_to_binary |> :base64.encode
     encoded <> "--" <> digest(secret, encoded)
   end
 

--- a/test/dynamo/utils/message_verifier_test.exs
+++ b/test/dynamo/utils/message_verifier_test.exs
@@ -5,7 +5,7 @@ defmodule Dynamo.Utils.MessageVerifierTest do
 
   test "generates a signed message" do
     [content, encoded] = String.split MV.generate("secret", :hello), "--"
-    assert content |> :base64.decode |> binary_to_term == :hello
+    assert content |> :base64.decode |> :erlang.binary_to_term == :hello
     assert size(encoded) == 40
   end
 
@@ -21,7 +21,7 @@ defmodule Dynamo.Utils.MessageVerifierTest do
 
   test "does not verify a tampered message" do
     [_, encoded] = String.split MV.generate("secret", :hello), "--"
-    content = :bye |> term_to_binary |> :base64.encode
+    content = :bye |> :erlang.term_to_binary |> :base64.encode
     assert MV.verify("secret", content <> "--" <> encoded) == :error
   end
 end


### PR DESCRIPTION
The Kernel functions binary_to_term and term_to_binary where deprecated on the 17th. When using the latest Elixir build you receive warning messages. Went ahead and updated based on the message. 
