### PR TITLE
update HTTP case method macros to pass both conn and body

### DIFF
--- a/lib/dynamo/http/case.ex
+++ b/lib/dynamo/http/case.ex
@@ -178,7 +178,7 @@ defmodule Dynamo.HTTP.Case do
   end
 
   defp do_method_with_body(method, arg1, arg2, arg3) when is_list(arg3) do
-    do_method method, arg1, arg2, UIR.encode_query(arg3)
+    do_method method, arg1, arg2, URI.encode_query(arg3)
   end
 
   defp do_method_with_body(method, arg1, arg2, arg3) do
@@ -246,7 +246,7 @@ defmodule Dynamo.HTTP.Case do
     do_process endpoint, conn.req(method, path, body)
   end
 
-  def do_process(endpoint, conn) do
+  defp do_process(endpoint, conn) do
     conn = endpoint.service(conn)
 
     if not is_tuple(conn) or not function_exported?(elem(conn, 0), :state, 1) do

--- a/lib/dynamo/http/case.ex
+++ b/lib/dynamo/http/case.ex
@@ -116,12 +116,8 @@ defmodule Dynamo.HTTP.Case do
       post(conn, "/foo", [{"foo", "bar"}]) # POSTs to `/foo` with `foo=bar` body
 
   """
-  defmacro post(arg1, arg2 \\ nil) do
-    if is_list(arg2) do
-      do_method :POST, arg1, URI.encode_query(arg2)
-    else
-      do_method :POST, arg1, arg2
-    end
+  defmacro post(arg1, arg2 \\ nil, arg3 \\ nil) do
+    do_method_with_body :POST, arg1, arg2, arg3
   end
 
   @doc """
@@ -129,10 +125,13 @@ defmodule Dynamo.HTTP.Case do
 
       put("/foo")
       put(conn, "/foo")
+      put(conn, "/foo", "test body")
+      put(conn, "/foo", [{"foo", "bar"}])
 
   """
-  defmacro put(arg1, arg2 \\ nil) do
+  defmacro put(arg1, arg2 \\ nil, arg3 \\ nil) do
     do_method :PUT, arg1, arg2
+    do_method_with_body :PUT, arg1, arg2, arg3
   end
 
   @doc """
@@ -140,10 +139,12 @@ defmodule Dynamo.HTTP.Case do
 
       patch("/foo")
       patch(conn, "/foo")
+      patch(conn, "/foo", "test body")
+      patch(conn, "/foo", [{"foo", "bar"}])
 
   """
-  defmacro patch(arg1, arg2 \\ nil) do
-    do_method :PATCH, arg1, arg2
+  defmacro patch(arg1, arg2 \\ nil, arg3 \\ nil) do
+    do_method_with_body :PATH, arg1, arg2, arg3
   end
 
   @doc """
@@ -168,6 +169,22 @@ defmodule Dynamo.HTTP.Case do
     do_method :OPTIONS, arg1, arg2
   end
 
+  defp do_method_with_body(method, arg1, arg2, nil) when is_list(arg2) do
+    do_method method, arg1, URI.encode_query(arg2)
+  end
+
+  defp do_method_with_body(method, arg1, arg2, nil) do
+    do_method method, arg1, arg2
+  end
+
+  defp do_method_with_body(method, arg1, arg2, arg3) when is_list(arg3) do
+    do_method method, arg1, arg2, UIR.encode_query(arg3)
+  end
+
+  defp do_method_with_body(method, arg1, arg2, arg3) do
+    do_method(method, arg1, arg2, arg3)
+  end
+
   defp do_method(method, arg1, nil) do
     quote do
       unquote(__MODULE__).process @endpoint, unquote(method), unquote(arg1)
@@ -177,6 +194,12 @@ defmodule Dynamo.HTTP.Case do
   defp do_method(method, arg1, arg2) do
     quote do
       unquote(__MODULE__).process @endpoint, unquote(arg1), unquote(method), unquote(arg2)
+    end
+  end
+
+  defp do_method(method, conn, path, body) do
+    quote do
+      unquote(__MODULE__).process @endpoint, unquote(conn), unquote(method), unquote(path), unquote(body)
     end
   end
 
@@ -203,22 +226,27 @@ defmodule Dynamo.HTTP.Case do
       process MyDynamo, conn, :get, "/foo"
 
   """
-  def process(endpoint, conn, method, path \\ nil)
+  def process(endpoint, conn, method, path \\ nil, body \\ nil)
 
-  def process(endpoint, conn, method, path) when is_tuple(conn) do
+  def process(endpoint, method, path, nil, nil) do
+    do_process endpoint, Dynamo.Connection.Test.new(method, path)
+  end
+
+  def process(endpoint, conn, method, path, nil) when is_tuple(conn) do
     conn = if conn.sent_body, do: conn.recycle, else: conn
     do_process endpoint, conn.req(method, path)
   end
 
-  def process(endpoint, method, path, nil) do
-    do_process endpoint, Dynamo.Connection.Test.new(method, path)
-  end
-
-  def process(endpoint, path, method, body) when is_binary(path) do
+  def process(endpoint, path, method, body, nil) when is_binary(path) do
     do_process endpoint, conn(method, path, body)
   end
 
-  defp do_process(endpoint, conn) do
+  def process(endpoint, conn, method, path, body) do
+    conn = if conn.sent_body, do: conn.recycle, else: conn
+    do_process endpoint, conn.req(method, path, body)
+  end
+
+  def do_process(endpoint, conn) do
     conn = endpoint.service(conn)
 
     if not is_tuple(conn) or not function_exported?(elem(conn, 0), :state, 1) do

--- a/test/dynamo/http/case_test.exs
+++ b/test/dynamo/http/case_test.exs
@@ -20,6 +20,13 @@ defmodule Dynamo.HTTP.CaseTest do
       conn = conn.fetch :body
       conn.send 200, conn.req_body
     end
+
+    post "/post_cookie" do
+      conn = conn.fetch :cookies
+      conn = conn.fetch :body
+      { "token", token, _ } = List.keyfind(conn.resp_cookies, "token", 0)
+      conn.send 200, "body(#{conn.req_body}) token(#{token})"
+    end
   end
 
   use ExUnit.Case
@@ -51,5 +58,11 @@ defmodule Dynamo.HTTP.CaseTest do
   test "sees the request body from a post with HashDict" do
     conn = post("/test_post", [{"foo", "bar"}, {"bar", "foo"}])
     assert conn.sent_body == "foo=bar&bar=foo"
+  end
+
+  test "sees the cookie from the post request" do
+    conn = put_cookie conn(:post, "/"), :token, "1a2b3c"
+    conn = post(conn, "/post_cookie", "hello")
+    assert conn.sent_body == "body(hello) token(1a2b3c)"
   end
 end

--- a/test/dynamo/http/case_test.exs
+++ b/test/dynamo/http/case_test.exs
@@ -27,6 +27,11 @@ defmodule Dynamo.HTTP.CaseTest do
       { "token", token, _ } = List.keyfind(conn.resp_cookies, "token", 0)
       conn.send 200, "body(#{conn.req_body}) token(#{token})"
     end
+
+    put "/put_cookie" do
+      conn = conn.fetch :body
+      conn.send 200, conn.req_body
+    end
   end
 
   use ExUnit.Case
@@ -64,5 +69,11 @@ defmodule Dynamo.HTTP.CaseTest do
     conn = put_cookie conn(:post, "/"), :token, "1a2b3c"
     conn = post(conn, "/post_cookie", "hello")
     assert conn.sent_body == "body(hello) token(1a2b3c)"
+  end
+
+  test "sees the request body from a HashDict when reusing the connection" do
+    conn = put_cookie conn(:post, "/"), :token, "qazwsx"
+    conn = put(conn, "/put_cookie", [{ "first", "Serge" }, { "last", "Gainsbourg" }])
+    assert conn.sent_body == "first=Serge&last=Gainsbourg"
   end
 end


### PR DESCRIPTION
I needed to test routers where I set a cookie on a post/put/patch request and also pass a path and a body.

This pull request allows to do that, and can be used like so:

``` elixir
conn = put_cookie conn(:post, "/"), :token, "1a2b3c"
conn = post(conn, "/create", "name=maya")
```

This examples allows to both set a cookie "token" and a body, which can be handy when you want to do token based authentication without using a session.
