### PR TITLE
Set required elixir version to the actual required version (0.12.4-dev)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Dynamo.Mixfile do
 
   def project do
     [ app: :dynamo,
-      elixir: "~> 0.12.0",
+      elixir: "~> 0.12.4-dev",
       version: "0.1.0-dev",
       name: "Dynamo",
       source_url: "https://github.com/dynamo/dynamo",


### PR DESCRIPTION
Bumps required elixir version in mix.exs.
