### PR TITLE
Add a note about how to run examples in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,8 @@ In the [guides](guides) directory we include a bunch of small, simple guides tha
 
 * [How to use SSL](guides/how-to-ssl.md)
 
+There are also a number of examples of dynamo features in the `examples/` directory. Look at the top each file for directions of how to run them.
+
 # License
 
 Dynamo source code is released under Apache 2 License.


### PR DESCRIPTION
So as said in issue #201 I add the note at the bottom of the README, no other place mentions examples and it seemed appropriate to put here. I did not change the language much.
