### PR TITLE
Updates for elixir v0.12.5

### DIFF
--- a/lib/dynamo/connection.ex
+++ b/lib/dynamo/connection.ex
@@ -402,7 +402,7 @@ defmodule Dynamo.Connection do
   """
   defcallback private(conn) :: assigns
 
-  @doc %S"""
+  @doc ~S"""
   Sets a new private assign with the given key and value.
   We recommended private keys to follow the format:
 

--- a/lib/dynamo/connection/query_parser.ex
+++ b/lib/dynamo/connection/query_parser.ex
@@ -54,7 +54,7 @@ defmodule Dynamo.Connection.QueryParser do
       #
       #     users[address][street] #=> [ _, "users", "address][street" ]
       #
-      case Regex.run(%r"^([^\[]+)\[(.*)\]$", key) do
+      case Regex.run(~r"^([^\[]+)\[(.*)\]$", key) do
         [_all, key, subpart] ->
           [key|String.split(subpart, "][", trim: false)]
         _ ->

--- a/lib/dynamo/http/case.ex
+++ b/lib/dynamo/http/case.ex
@@ -1,5 +1,5 @@
 defmodule Dynamo.HTTP.Case do
-  @moduledoc %S"""
+  @moduledoc ~S"""
   A bunch of helpers to make it easy to test Dynamos and routers.
 
   By default, these helpers are macros that dispatch directly

--- a/lib/dynamo/http/redirect.ex
+++ b/lib/dynamo/http/redirect.ex
@@ -27,7 +27,7 @@ defmodule Dynamo.HTTP.Redirect do
       # combination of letters, digits, and the plus ("+"),
       # period ("."), or hyphen ("-") characters; and is
       # terminated by a colon (":").
-      unless to =~ %r{^(\w[\w+.-]*:|//).*} do
+      unless to =~ ~r{^(\w[\w+.-]*:|//).*} do
         to = conn.host_url <> to
       end
     else
@@ -51,6 +51,6 @@ defmodule Dynamo.HTTP.Redirect do
     Dynamo.HTTP.Halt.halt! redirect(conn, opts)
   end
 
-  defp redirect_body("text/html", to), do: %s[<html><body>You are being <a href="#{to}">redirected</a>.</body></html>]
+  defp redirect_body("text/html", to), do: ~s[<html><body>You are being <a href="#{to}">redirected</a>.</body></html>]
   defp redirect_body(_, _), do: ""
 end

--- a/lib/mix/tasks/dynamo.ex
+++ b/lib/mix/tasks/dynamo.ex
@@ -53,9 +53,9 @@ defmodule Mix.Tasks.Dynamo do
     lib = underscore(mod)
 
     dynamo = if opts[:dev] do
-      %s(path: "#{Path.expand("../../..", __DIR__)}")
+      ~s(path: "#{Path.expand("../../..", __DIR__)}")
     else
-      %s(github: "elixir-lang/dynamo")
+      ~s(github: "elixir-lang/dynamo")
     end
 
     assigns = [app: app, mod: mod, dynamo: dynamo, version: @version]
@@ -98,7 +98,7 @@ defmodule Mix.Tasks.Dynamo do
   end
 
   defp check_project_name!(name) do
-    unless name =~ %r/^[a-z][\w_]+$/ do
+    unless name =~ ~r/^[a-z][\w_]+$/ do
       raise Mix.Error, message: "project path must start with a letter and have only lowercase letters, numbers and underscore"
     end
     if Code.ensure_loaded?(Module.concat([String.capitalize(name)])) do
@@ -128,7 +128,7 @@ defmodule Mix.Tasks.Dynamo do
   erl_crash.dump
   """
 
-  embed_template :mixfile, %S"""
+  embed_template :mixfile, ~S"""
   defmodule <%= @mod %>.Mixfile do
     use Mix.Project
 

--- a/mix.lock
+++ b/mix.lock
@@ -2,6 +2,6 @@
   "cowlib": {:git, "git://github.com/extend/cowlib.git", "0d4ece08a7cce90a07cf33d4edad29bc324c7d90", [ref: "0.5.1"]},
   "hackney": {:git, "git://github.com/benoitc/hackney.git", "7f2a0b5996313d930277786e7ff5d538e9346547", [tag: "0.10.1"]},
   "hackney_lib": {:git, "https://github.com/benoitc/hackney_lib.git", "eecdb481f1d38bfb194896bffdf9bdcdd967ae96", [tag: "0.2.2"]},
-  "mime": {:git, "git://github.com/dynamo/mime.git", "7e56a3dd5692afcd39c9797ae2898c5841967098", []},
+  "mime": {:git, "git://github.com/dynamo/mime.git", "db84370c53a67a7e58a4d0cfb026f4edc64a9367", []},
   "mimetypes": {:git, "git://github.com/spawngrid/mimetypes.git", "47d37a977a7d633199822bf6b08353007483d00f", [ref: "master"]},
   "ranch": {:git, "git://github.com/extend/ranch.git", "5df1f222f94e08abdcab7084f5e13027143cc222", [ref: "0.9.0"]} ]

--- a/test/dynamo/cowboy/connection_test.exs
+++ b/test/dynamo/cowboy/connection_test.exs
@@ -208,9 +208,9 @@ defmodule Dynamo.Cowboy.ConnectionTest do
   end
 
   test :req_cookies do
-    assert_success request :get, "/req_cookies_0", [{ "Cookie", %s(foo=bar; baz=bat) }]
-    assert_success request :get, "/req_cookies_1", [{ "Cookie", %s(foo=bar; baz=bat) }]
-    assert_success request :get, "/req_cookies_2", [{ "Cookie", %s(foo=bar=baz) }]
+    assert_success request :get, "/req_cookies_0", [{ "Cookie", ~s(foo=bar; baz=bat) }]
+    assert_success request :get, "/req_cookies_1", [{ "Cookie", ~s(foo=bar; baz=bat) }]
+    assert_success request :get, "/req_cookies_2", [{ "Cookie", ~s(foo=bar=baz) }]
   end
 
   test :resp_cookies do
@@ -225,12 +225,12 @@ defmodule Dynamo.Cowboy.ConnectionTest do
   end
 
   test :req_resp_cookies do
-    response = request :get, "/req_resp_cookies", [{ "Cookie", %s(foo=bar; baz=bat) }]
+    response = request :get, "/req_resp_cookies", [{ "Cookie", ~s(foo=bar; baz=bat) }]
     assert_success response
 
     { _, headers, _ } = response
     { "set-cookie", contents } = List.keyfind(headers, "set-cookie", 0)
-    assert contents =~ %r"foo=; path=/; expires=Thu, 01 Jan 1970 12:00:00 GMT; max-age=0; HttpOnly"
+    assert contents =~ ~r"foo=; path=/; expires=Thu, 01 Jan 1970 12:00:00 GMT; max-age=0; HttpOnly"
 
     headers = List.keydelete(headers, "set-cookie", 0)
     assert List.keyfind(headers, "set-cookie", 0) == nil

--- a/test/dynamo/filters/exceptions/debug_test.exs
+++ b/test/dynamo/filters/exceptions/debug_test.exs
@@ -17,35 +17,35 @@ defmodule Dynamo.Filters.Exceptions.DebugTest do
   test "prints exception name and title" do
     conn = @endpoint.service(conn)
     assert conn.status == 500
-    assert conn.sent_body =~ %r"ArgumentError"
-    assert conn.sent_body =~ %r"bad argument"
+    assert conn.sent_body =~ ~r"ArgumentError"
+    assert conn.sent_body =~ ~r"bad argument"
   end
 
   test "shows shortcut file path, module and function" do
     conn = @endpoint.service(conn)
-    assert conn.sent_body =~ %r"\bfilters/exceptions/debug_test.exs\b"
-    assert conn.sent_body =~ %r"\bDynamo.Filters.Exceptions.DebugTest\b"
-    assert conn.sent_body =~ %r"\bstacktrace/0\b"
+    assert conn.sent_body =~ ~r"\bfilters/exceptions/debug_test.exs\b"
+    assert conn.sent_body =~ ~r"\bDynamo.Filters.Exceptions.DebugTest\b"
+    assert conn.sent_body =~ ~r"\bstacktrace/0\b"
   end
 
   test "handles __MODULE__ stacktraces" do
     conn = @endpoint.service(conn)
-    assert conn.sent_body =~ %r"Dynamo.Filters.Exceptions.DebugTest \(module\)"
+    assert conn.sent_body =~ ~r"Dynamo.Filters.Exceptions.DebugTest \(module\)"
   end
 
   test "show editor links" do
     conn = @endpoint.service(conn)
-    assert conn.sent_body =~ %r"editor://#{URI.encode __ENV__.file}:#{16}"
+    assert conn.sent_body =~ ~r"editor://#{URI.encode __ENV__.file}:#{16}"
   end
 
   test "shows snippets if they are part of the source_paths" do
     conn = @endpoint.service(conn)
-    assert conn.sent_body =~ %r"@endpoint Dynamo.Filters.Exceptions.Debug"
+    assert conn.sent_body =~ ~r"@endpoint Dynamo.Filters.Exceptions.Debug"
   end
 
   test "does not show snippets if they are not part of the source_paths" do
     conn = @endpoint.service(conn)
-    assert conn.sent_body =~ %r"No code snippets for code outside the Dynamo"
+    assert conn.sent_body =~ ~r"No code snippets for code outside the Dynamo"
   end
 
   defp conn do

--- a/test/dynamo/http/redirect_test.exs
+++ b/test/dynamo/http/redirect_test.exs
@@ -30,7 +30,7 @@ defmodule Dynamo.HTTP.RedirectTest do
   test :redirect_with_set_content_type do
     conn = redirect conn(:GET, "/").resp_content_type("text/html"), to: "/foo"
     assert conn.resp_headers["location"] == "http://127.0.0.1/foo"
-    assert conn.resp_body =~ %r"redirected"
+    assert conn.resp_body =~ ~r"redirected"
   end
 
   test :redirect_with_full_url do

--- a/test/dynamo/http/render_test.exs
+++ b/test/dynamo/http/render_test.exs
@@ -123,6 +123,6 @@ defmodule Dynamo.HTTP.RenderTest do
   end
 
   defp strip_lines(body) do
-    Regex.replace %r"\n+\s*", body, "\n"
+    Regex.replace ~r"\n+\s*", body, "\n"
   end
 end

--- a/test/mix/tasks/dynamo_test.exs
+++ b/test/mix/tasks/dynamo_test.exs
@@ -21,22 +21,22 @@ defmodule Mix.Tasks.DynamoTest do
       Mix.Tasks.Dynamo.run ["."]
 
       assert_file "mix.exs", fn(file) ->
-        assert file =~ %r(app: :my_app)
-        assert file =~ %r(version: "0.0.1")
-        assert file =~ %r({ :dynamo)
-        assert file =~ %r(github: "elixir-lang/dynamo")
+        assert file =~ ~r(app: :my_app)
+        assert file =~ ~r(version: "0.0.1")
+        assert file =~ ~r({ :dynamo)
+        assert file =~ ~r(github: "elixir-lang/dynamo")
       end
 
-      assert_file "README.md", %r(# MyApp)
+      assert_file "README.md", ~r(# MyApp)
       assert_file ".gitignore"
 
       assert_file "lib/my_app.ex", fn(file) ->
-        assert file =~ %r(use Application.Behaviour)
+        assert file =~ ~r(use Application.Behaviour)
       end
 
       assert_file "lib/my_app/dynamo.ex", fn(file) ->
-        assert file =~ %r(endpoint: ApplicationRouter)
-        assert file =~ %r(env: Mix.env)
+        assert file =~ ~r(endpoint: ApplicationRouter)
+        assert file =~ ~r(env: Mix.env)
       end
 
       assert_file "web/routers/application_router.ex"
@@ -60,7 +60,7 @@ defmodule Mix.Tasks.DynamoTest do
       Mix.Tasks.Dynamo.run [".", "--dev"]
 
       assert_file "mix.exs", fn(file) ->
-        assert file =~ %r(path:)
+        assert file =~ ~r(path:)
       end
 
       assert_received { :mix_shell, :info, ["* creating mix.exs"] }

--- a/test/mix/tasks_test.exs
+++ b/test/mix/tasks_test.exs
@@ -7,17 +7,17 @@ defmodule Mix.TasksTest do
       app_with_dynamo_deps_path(:prod)
 
       output = System.cmd "MIX_ENV=prod mix compile"
-      assert output =~ %r(Compiled web/routers/application_router.ex)
-      assert output =~ %r(Compiled lib/my_app.ex)
-      assert output =~ %r(Compiled lib/my_app/dynamo.ex)
-      assert output =~ %r(Generated my_compiled_app.app)
-      assert output =~ %r(Generated MyApp.Dynamo.CompiledTemplates)
+      assert output =~ ~r(Compiled web/routers/application_router.ex)
+      assert output =~ ~r(Compiled lib/my_app.ex)
+      assert output =~ ~r(Compiled lib/my_app/dynamo.ex)
+      assert output =~ ~r(Generated my_compiled_app.app)
+      assert output =~ ~r(Generated MyApp.Dynamo.CompiledTemplates)
       assert File.regular?("_build/prod/lib/my_compiled_app/ebin/Elixir.MyApp.Dynamo.CompiledTemplates.beam")
 
       # Can recompile after changes
       File.touch!("web/routers/application_router.ex", { { 2030, 1, 1 }, { 0, 0, 0 } })
       output = System.cmd "MIX_ENV=prod mix compile"
-      assert output =~ %r(Compiled web/routers/application_router.ex)
+      assert output =~ ~r(Compiled web/routers/application_router.ex)
     end
   end
 
@@ -26,9 +26,9 @@ defmodule Mix.TasksTest do
       app_with_dynamo_deps_path(:dev)
 
       output = System.cmd "mix dynamo.filters"
-      assert output =~ %r(filter Dynamo.Filters.Head)
-      assert output =~ %r(filter \{Dynamo.Filters.Loader, *true, *true\})
-      assert output =~ %r(ApplicationRouter.service/1)
+      assert output =~ ~r(filter Dynamo.Filters.Head)
+      assert output =~ ~r(filter \{Dynamo.Filters.Loader, *true, *true\})
+      assert output =~ ~r(ApplicationRouter.service/1)
     end
   end
 
@@ -36,8 +36,8 @@ defmodule Mix.TasksTest do
     in_tmp "my_run_app", fn ->
       app_with_dynamo_deps_path(:dev)
 
-      output = System.cmd %s{mix run -e "IO.inspect HelloRouter.__info__(:module)"}
-      assert output =~ %r(HelloRouter)
+      output = System.cmd ~s{mix run -e "IO.inspect HelloRouter.__info__(:module)"}
+      assert output =~ ~r(HelloRouter)
     end
   end
 
@@ -55,8 +55,8 @@ defmodule Mix.TasksTest do
       end
       """
 
-      output = System.cmd %s{unset MIX_ENV; mix test}
-      assert output =~ %r(3 tests, 0 failures)
+      output = System.cmd ~s{unset MIX_ENV; mix test}
+      assert output =~ ~r(3 tests, 0 failures)
     end
   end
 
@@ -70,7 +70,7 @@ defmodule Mix.TasksTest do
     :ok = :file.make_symlink("../../deps", "deps")
 
     File.write! "mix.exs",
-      Regex.replace(%r"deps: deps", File.read!("mix.exs"), %s(deps: deps, deps_path: "../../deps"))
+      Regex.replace(~r"deps: deps", File.read!("mix.exs"), ~s(deps: deps, deps_path: "../../deps"))
 
     File.write! "web/routers/hello_router.ex", """
     defmodule HelloRouter do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -29,12 +29,13 @@ defmodule MixHelpers do
     assert File.regular?(file), "Expected #{file} to exist, but does not"
   end
 
-  def assert_file(file, match) when is_regex(match) do
-    &assert_file(file, &1 =~ match)
-  end
-
-  def assert_file(file, callback) when is_function(callback, 1) do
-    assert_file(file)
-    callback.(File.read!(file))
+  def assert_file(file, match) do
+    cond do
+      Regex.regex?(match) ->
+        &assert_file(file, &1 =~ match)
+      is_function(match, 1) ->
+        assert_file(file)
+        match.(File.read!(file))
+    end
   end
 end


### PR DESCRIPTION
Catching up to some deprecations.

[is_regex -> Regex.regex?/1] one is changed as similar way as "lib/mix/test/mix/tasks/new_test.exs" in the following commit.
https://github.com/elixir-lang/elixir/commit/2cc4fd2eb5f5a70c4dafd5a72eb4fd0d1c399a41
