### PR TITLE
Some fixes for elixir v0.13.1

### DIFF
--- a/lib/dynamo/router/base.ex
+++ b/lib/dynamo/router/base.ex
@@ -521,7 +521,7 @@ defmodule Dynamo.Router.Base do
   end
 
   defp is_mod_fun?({ mod, fun } = ref, kind) when is_atom(mod) and is_atom(fun) do
-    not function_exported?(ref, kind, 1)
+    not Dynamo.Router.Utils.is_function_exported?(ref, kind, 1)
   end
 
   defp is_mod_fun?(_ref, _kind), do: false

--- a/lib/dynamo/router/filters.ex
+++ b/lib/dynamo/router/filters.ex
@@ -132,16 +132,16 @@ defmodule Dynamo.Router.Filters do
         escaped = Macro.escape(filter)
 
         cond do
-          function_exported?(filter, :service, 2)  ->
+          Dynamo.Router.Utils.is_function_exported?(filter, :service, 2)  ->
             quote do
               unquote(escaped).service(conn, fn(conn) -> unquote(acc) end)
             end
-          function_exported?(filter, :prepare, 1)  ->
+          Dynamo.Router.Utils.is_function_exported?(filter, :prepare, 1)  ->
             quote do
               conn = unquote(escaped).prepare(conn)
               unquote(acc)
             end
-          function_exported?(filter, :finalize, 1)  ->
+          Dynamo.Router.Utils.is_function_exported?(filter, :finalize, 1)  ->
             quote do
               unquote(escaped).finalize(unquote(acc))
             end

--- a/lib/dynamo/router/utils.ex
+++ b/lib/dynamo/router/utils.ex
@@ -146,4 +146,13 @@ defmodule Dynamo.Router.Utils do
   defp binary_from_buffer(buffer) do
     iolist_to_binary(Enum.reverse(buffer))
   end
+
+  def is_function_exported?(module, function, arity) do
+    case is_tuple(module) do
+      true  ->
+        function_exported?(elem(module, 0), function, arity + 1)
+      false ->
+        function_exported?(module, function, arity)
+    end
+  end
 end

--- a/lib/mix/tasks/compile.dynamo.ex
+++ b/lib/mix/tasks/compile.dynamo.ex
@@ -51,7 +51,7 @@ defmodule Mix.Tasks.Compile.Dynamo do
   The manifests for this compiler.
   """
   def manifests, do: [manifest]
-  defp manifest, do: Path.join(Mix.project[:compile_path], @manifest)
+  defp manifest, do: Path.join(Mix.Project.compile_path, @manifest)
 
   defp do_compile(mod, opts, acc) do
     root    = File.cwd!

--- a/test/mix/tasks/dynamo_test.exs
+++ b/test/mix/tasks/dynamo_test.exs
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.DynamoTest do
         assert file =~ ~r(app: :my_app)
         assert file =~ ~r(version: "0.0.1")
         assert file =~ ~r({ :dynamo)
-        assert file =~ ~r(github: "elixir-lang/dynamo")
+        assert file =~ ~r(github: "dynamo/dynamo")
       end
 
       assert_file "README.md", ~r(# MyApp)


### PR DESCRIPTION
Hi. I've tried to fix some errors while I was working on v0.13.1.

(1) Update elixir-lang/dynamo with dynamo/dynamo in Mix.Tasks.DynamoTest
  test update for https://github.com/dynamo/dynamo/commit/d14d2167c29474ee5b1e211ccc17ed891036c37d fix.

(2) Fix Mix.Project.compile_path for avoiding FunctionClauseError at v0.13.1
 It was causing [mix test] error. It seems because Path.join(nil, xxx) started raising exception at v0.13.1 after https://github.com/elixir-lang/elixir/commit/6624f31472bccc2c0ce456a94cc6532ae6c422f3, 

(3) Add tuple check logic for function_exported? as it is removed at elixir v0.13.1
  Tuple becomes unsupported for function_exported? (https://github.com/elixir-lang/elixir/commit/f9329379282515fab95efe7d5f2781c262303aac), and moved the logic into dynamo code.
