### PR TITLE
Use elixir v0.13.1 for travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ notifications:
 otp_release:
   - 17.0
 before_install:
-  - git clone git://github.com/elixir-lang/elixir --depth 1
-  - make -C elixir
+  - mkdir -p vendor/elixir
+  - wget -q https://github.com/elixir-lang/elixir/releases/download/v0.13.1/Precompiled.zip && unzip -qq Precompiled.zip -d vendor/elixir
+  - export PATH="$PATH:$PWD/vendor/elixir/bin"
 before_script: "export PATH=`pwd`/elixir/bin:$PATH"
 script: "MIX_ENV=test mix do deps.get, test"


### PR DESCRIPTION
How do you think about testing against the latest stable release? 
It seems some amount of changes are required for v0.13.2-dev regarding Maps.
