### PR TITLE
Records -> Structs

### DIFF
--- a/lib/dynamo/connection.ex
+++ b/lib/dynamo/connection.ex
@@ -1,9 +1,10 @@
 defmodule Dynamo.Connection do
-  defrecord File, path: nil, name: nil, content_type: nil, filename: nil do
+  defmodule File do
     @moduledoc """
     Contains a file representation whenever there is a multipart
     request and it contains a File.
     """
+    defstruct [path: nil, name: nil, content_type: nil, filename: nil]
   end
 
   defexception UnfetchedError, aspect: nil do

--- a/lib/dynamo/connection/behaviour.ex
+++ b/lib/dynamo/connection/behaviour.ex
@@ -128,7 +128,7 @@ defmodule Dynamo.Connection.Behaviour do
 
       @doc false
       def route_params(new, connection(params: params, route_params: route_params) = conn) do
-        connection(conn, route_params: route_params ++ new, params: Dict.merge(params, new))
+        connection(conn, route_params: route_params ++ new, params: Binary.Dict.merge(params, new))
       end
 
       @doc false

--- a/lib/dynamo/connection/behaviour.ex
+++ b/lib/dynamo/connection/behaviour.ex
@@ -1,9 +1,8 @@
 defmodule Dynamo.Connection.Behaviour do
   @moduledoc """
   Common behaviour used between `Dynamo.Connection` connection
-  implementations. When used, it defines a private record
-  via `defrecordp` named `connection` with the following fields
-  and their default values:
+  implementations. When used, it defines a module `Connection` 
+  containing a struct with the following fields and their default values:
 
   * assigns - an empty list
   * params - `nil`
@@ -63,255 +62,257 @@ defmodule Dynamo.Connection.Behaviour do
     quote location: :keep do
       @behaviour Dynamo.Connection
 
-      defrecordp :connection, __MODULE__, unquote(fields)
+      defmodule Connection do
+        defstruct unquote(fields)
 
-      ## Assigns
+        ## Assigns
 
-      @doc false
-      def assigns(connection(assigns: assigns)) do
-        assigns
-      end
+        @doc false
+        def assigns(%Connection{assigns: assigns}) do
+          assigns
+        end
 
-      @doc false
-      def assign(key, value, connection(assigns: assigns) = conn) do
-        connection(conn, assigns: Keyword.put(assigns, key, value))
-      end
+        @doc false
+        def assign(key, value, %Connection{assigns: assigns} = conn) do
+          %Connection{conn | assigns: Keyword.put(assigns, key, value)}
+        end
 
-      @doc false
-      def put_assign(key, value, conn) do
-        assign(key, value, conn)
-      end
+        @doc false
+        def put_assign(key, value, conn) do
+          assign(key, value, conn)
+        end
 
-      @doc false
-      def private(connection(private: private)) do
-        private
-      end
+        @doc false
+        def private(%Connection{private: private}) do
+          private
+        end
 
-      @doc false
-      def put_private(key, value, connection(private: private) = conn) do
-        connection(conn, private: Keyword.put(private, key, value))
-      end
+        @doc false
+        def put_private(key, value, %Connection{private: private} = conn) do
+          %Connection{conn | private: Keyword.put(private, key, value)}
+        end
 
-      @doc false
-      def main(connection(main: main)) do
-        main
-      end
+        @doc false
+        def main(%Connection{main: main}) do
+          main
+        end
 
-      ## Fetch
+        ## Fetch
 
-      @doc false
-      def fetchable(atom, fun, connection(fetchable: fetchable) = conn) when is_atom(atom) and is_function(fun, 1) do
-        connection(conn, fetchable: [{ atom, fun }|fetchable])
-      end
+        @doc false
+        def fetchable(atom, fun, %Connection{fetchable: fetchable} = conn) when is_atom(atom) and is_function(fun, 1) do
+          %Connection{conn | fetchable: [{ atom, fun }|fetchable]}
+        end
 
-      ## Request
+        ## Request
 
-      @doc false
-      def params(connection(params: nil)) do
-        raise Dynamo.Connection.UnfetchedError, aspect: :params
-      end
+        @doc false
+        def params(%Connection{params: nil}) do
+          raise Dynamo.Connection.UnfetchedError, aspect: :params
+        end
 
-      @doc false
-      def params(connection(params: params)) do
-        params
-      end
+        @doc false
+        def params(%Connection{params: params}) do
+          params
+        end
 
-      @doc false
-      def route_params(connection(route_params: route_params)) do
-        route_params
-      end
+        @doc false
+        def route_params(%Connection{route_params: route_params}) do
+          route_params
+        end
 
-      @doc false
-      def route_params(new, connection(params: nil, route_params: route_params) = conn) do
-        connection(conn, route_params: route_params ++ new)
-      end
+        @doc false
+        def route_params(new, %Connection{params: nil, route_params: route_params} = conn) do
+          %Connection{conn | route_params: route_params ++ new}
+        end
 
-      @doc false
-      def route_params(new, connection(params: params, route_params: route_params) = conn) do
-        connection(conn, route_params: route_params ++ new, params: Dict.merge(params, new))
-      end
+        @doc false
+        def route_params(new, %Connection{params: params, route_params: route_params} = conn) do
+          %Connection{conn | route_params: route_params ++ new, params: Dict.merge(params, new)}
+        end
 
-      @doc false
-      def method(connection(method: method)) do
-        method
-      end
+        @doc false
+        def method(%Connection{method: method}) do
+          method
+        end
 
-      @doc false
-      def method(method, conn) when is_binary(method) do
-        connection(conn, method: method)
-      end
+        @doc false
+        def method(method, conn) when is_binary(method) do
+          %Connection{conn | method: method}
+        end
 
-      @doc false
-      def req_headers(connection(req_headers: nil)) do
-        raise Dynamo.Connection.UnfetchedError, aspect: :req_headers
-      end
+        @doc false
+        def req_headers(%Connection{req_headers: nil}) do
+          raise Dynamo.Connection.UnfetchedError, aspect: :req_headers
+        end
 
-      @doc false
-      def req_headers(connection(req_headers: req_headers)) do
-        req_headers
-      end
+        @doc false
+        def req_headers(%Connection{req_headers: req_headers}) do
+          req_headers
+        end
 
-      @doc false
-      def req_body(connection(req_body: nil)) do
-        raise Dynamo.Connection.UnfetchedError, aspect: :req_body
-      end
+        @doc false
+        def req_body(%Connection{req_body: nil}) do
+          raise Dynamo.Connection.UnfetchedError, aspect: :req_body
+        end
 
-      @doc false
-      def req_body(connection(req_body: req_body)) do
-        req_body
-      end
+        @doc false
+        def req_body(%Connection{req_body: req_body}) do
+          req_body
+        end
 
-      ## Cookies
+        ## Cookies
 
-      @doc false
-      def req_cookies(connection(req_cookies: nil)) do
-        raise Dynamo.Connection.UnfetchedError, aspect: :cookies
-      end
+        @doc false
+        def req_cookies(%Connection{req_cookies: nil}) do
+          raise Dynamo.Connection.UnfetchedError, aspect: :cookies
+        end
 
-      @doc false
-      def req_cookies(connection(req_cookies: req_cookies)) do
-        req_cookies
-      end
+        @doc false
+        def req_cookies(%Connection{req_cookies: req_cookies}) do
+          req_cookies
+        end
 
-      @doc false
-      def resp_cookies(connection(resp_cookies: resp_cookies)) do
-        resp_cookies
-      end
+        @doc false
+        def resp_cookies(%Connection{resp_cookies: resp_cookies}) do
+          resp_cookies
+        end
 
-      @doc false
-      def put_resp_cookie(key, value, opts, connection(resp_cookies: resp_cookies) = conn)
-          when is_binary(key) and (is_binary(value) or nil?(value)) and is_list(opts) do
-        resp_cookies = List.keydelete(resp_cookies, key, 0)
-        connection(conn, resp_cookies: [{ key, value, opts }|resp_cookies])
-      end
+        @doc false
+        def put_resp_cookie(key, value, opts, %Connection{resp_cookies: resp_cookies} = conn)
+            when is_binary(key) and (is_binary(value) or nil?(value)) and is_list(opts) do
+          resp_cookies = List.keydelete(resp_cookies, key, 0)
+          %Connection{conn, resp_cookies: [{ key, value, opts }|resp_cookies]}
+        end
 
-      ## Paths
+        ## Paths
 
-      @doc false
-      def path_info_segments(connection(path_info_segments: segments)) do
-        segments
-      end
+        @doc false
+        def path_info_segments(%Connection{path_info_segments: segments}) do
+          segments
+        end
 
-      @doc false
-      def path_info(connection(path_info_segments: segments)) do
-        to_path segments
-      end
+        @doc false
+        def path_info(%Connection{path_info_segments: segments}) do
+          to_path segments
+        end
 
-      @doc false
-      def script_name_segments(connection(script_name_segments: segments)) do
-        segments
-      end
+        @doc false
+        def script_name_segments(%Connection{script_name_segments: segments}) do
+          segments
+        end
 
-      @doc false
-      def script_name(connection(script_name_segments: segments)) do
-        to_path segments
-      end
+        @doc false
+        def script_name(%Connection{script_name_segments: segments}) do
+          to_path segments
+        end
 
-      @doc false
-      def forward_to(segments, _target,
-          connection(path_info_segments: path, script_name_segments: script) = conn) do
-        { prefix, ^segments } = Enum.split path, length(path) - length(segments)
+        @doc false
+        def forward_to(segments, _target,
+            %Connection{path_info_segments: path, script_name_segments: script} = conn) do
+          { prefix, ^segments } = Enum.split path, length(path) - length(segments)
 
-        connection(conn,
-          path_info_segments: segments,
-          script_name_segments: script ++ prefix
-        )
-      end
+          %Connection{conn |
+            path_info_segments: segments,
+            script_name_segments: script ++ prefix
+          }
+        end
 
-      defp to_path(segments) do
-        "/" <> Enum.join(segments, "/")
-      end
+        defp to_path(segments) do
+          "/" <> Enum.join(segments, "/")
+        end
 
-      ## Response
+        ## Response
 
-      @doc false
-      def status(connection(status: status)) do
-        status
-      end
+        @doc false
+        def status(%Connection{status: status}) do
+          status
+        end
 
-      @doc false
-      def status(status, connection(state: state) = conn) when
-          is_integer(status) and state in [:unset, :set, :sendfile, :chunked] do
-        connection(conn, status: status, state: :set)
-      end
+        @doc false
+        def status(status, %Connection{state: state} = conn) when
+            is_integer(status) and state in [:unset, :set, :sendfile, :chunked] do
+          %Connection{conn | status: status, state: :set}
+        end
 
-      @doc false
-      def resp_body(connection(resp_body: resp_body)) do
-        resp_body
-      end
+        @doc false
+        def resp_body(%Connection{resp_body: resp_body}) do
+          resp_body
+        end
 
-      @doc false
-      def resp_body(body, connection(status: status, state: state) = conn) when state in [:unset, :set] do
-        connection(conn,
-          status: status || 200,
-          resp_body: body,
-          state: :set)
-      end
+        @doc false
+        def resp_body(body, %Connection{status: status, state: state} = conn) when state in [:unset, :set] do
+          %Connection{conn |
+            status: status || 200,
+            resp_body: body,
+            state: :set}
+        end
 
-      @doc false
-      def resp_content_type(connection(resp_content_type: resp_content_type)) do
-        resp_content_type
-      end
+        @doc false
+        def resp_content_type(%Connection{resp_content_type: resp_content_type}) do
+          resp_content_type
+        end
 
-      @doc false
-      def resp_content_type(resp_content_type, conn) when is_binary(resp_content_type) do
-        connection(conn, resp_content_type: resp_content_type)
-      end
+        @doc false
+        def resp_content_type(resp_content_type, conn) when is_binary(resp_content_type) do
+          %Connection{conn | resp_content_type: resp_content_type}
+        end
 
-      @doc false
-      def resp_charset(connection(resp_charset: resp_charset)) do
-        resp_charset
-      end
+        @doc false
+        def resp_charset(%Connection{resp_charset: resp_charset}) do
+          resp_charset
+        end
 
-      @doc false
-      def resp_charset(resp_charset, conn) when is_binary(resp_charset) do
-        connection(conn, resp_charset: resp_charset)
-      end
+        @doc false
+        def resp_charset(resp_charset, conn) when is_binary(resp_charset) do
+          %Connection{conn | resp_charset: resp_charset}
+        end
 
-      @doc false
-      def resp(status, body, connection(state: state) = conn)
-          when is_integer(status) and state in [:unset, :set] do
-        connection(conn,
-          status: status,
-          resp_body: body,
-          state: :set
-        )
-      end
+        @doc false
+        def resp(status, body, %Connection{state: state} = conn)
+            when is_integer(status) and state in [:unset, :set] do
+          %Connection{conn |
+            status: status,
+            resp_body: body,
+            state: :set
+          }
+        end
 
-      @doc false
-      def send(connection(status: status, resp_body: body) = conn) do
-        send(status, body, conn)
-      end
+        @doc false
+        def send(%Connection{status: status, resp_body: body} = conn) do
+          send(status, body, conn)
+        end
 
-      @doc false
-      def state(connection(state: state)) do
-        state
-      end
+        @doc false
+        def state(%Connection{state: state}) do
+          state
+        end
 
-      @doc false
-      def resp_headers(connection(resp_headers: resp_headers)) do
-        resp_headers
-      end
+        @doc false
+        def resp_headers(%Connection{resp_headers: resp_headers}) do
+          resp_headers
+        end
 
-      @doc false
-      def put_resp_header(key, value, connection(resp_headers: resp_headers) = conn) do
-        connection(conn, resp_headers: Binary.Dict.put(resp_headers, key, to_string(value)))
-      end
+        @doc false
+        def put_resp_header(key, value, %Connection{resp_headers: resp_headers} = conn) do
+          %Connection{conn, resp_headers: Binary.Dict.put(resp_headers, key, to_string(value))}
+        end
 
-      @doc false
-      def delete_resp_header(key, connection(resp_headers: resp_headers) = conn) do
-        connection(conn, resp_headers: Binary.Dict.delete(resp_headers, key))
-      end
+        @doc false
+        def delete_resp_header(key, %Connection{resp_headers: resp_headers} = conn) do
+          %Connection{conn | resp_headers: Binary.Dict.delete(resp_headers, key)}
+        end
 
-      # Callbacks
+        # Callbacks
 
-      @doc false
-      def before_send(fun, connection(before_send: before_send) = conn) when is_function(fun) do
-        connection(conn, before_send: [fun|before_send])
-      end
+        @doc false
+        def before_send(fun, %Connection{before_send: before_send} = conn) when is_function(fun) do
+          %Connection{conn | before_send: [fun|before_send]}
+        end
 
-      defp run_before_send(connection(before_send: before_send) = conn) do
-        Enum.reduce Enum.reverse(before_send), conn, fn(fun, c) -> fun.(c) end
+        defp run_before_send(%Connection{before_send: before_send} = conn) do
+          Enum.reduce Enum.reverse(before_send), conn, fn(fun, c) -> fun.(c) end
+        end
       end
     end
 

--- a/lib/dynamo/connection/behaviour.ex
+++ b/lib/dynamo/connection/behaviour.ex
@@ -1,8 +1,9 @@
 defmodule Dynamo.Connection.Behaviour do
   @moduledoc """
   Common behaviour used between `Dynamo.Connection` connection
-  implementations. When used, it defines a module `Connection` 
-  containing a struct with the following fields and their default values:
+  implementations. When used, it defines a private record
+  via `defrecordp` named `connection` with the following fields
+  and their default values:
 
   * assigns - an empty list
   * params - `nil`
@@ -62,257 +63,255 @@ defmodule Dynamo.Connection.Behaviour do
     quote location: :keep do
       @behaviour Dynamo.Connection
 
-      defmodule Connection do
-        defstruct unquote(fields)
+      defrecordp :connection, __MODULE__, unquote(fields)
 
-        ## Assigns
+      ## Assigns
 
-        @doc false
-        def assigns(%Connection{assigns: assigns}) do
-          assigns
-        end
+      @doc false
+      def assigns(connection(assigns: assigns)) do
+        assigns
+      end
 
-        @doc false
-        def assign(key, value, %Connection{assigns: assigns} = conn) do
-          %Connection{conn | assigns: Keyword.put(assigns, key, value)}
-        end
+      @doc false
+      def assign(key, value, connection(assigns: assigns) = conn) do
+        connection(conn, assigns: Keyword.put(assigns, key, value))
+      end
 
-        @doc false
-        def put_assign(key, value, conn) do
-          assign(key, value, conn)
-        end
+      @doc false
+      def put_assign(key, value, conn) do
+        assign(key, value, conn)
+      end
 
-        @doc false
-        def private(%Connection{private: private}) do
-          private
-        end
+      @doc false
+      def private(connection(private: private)) do
+        private
+      end
 
-        @doc false
-        def put_private(key, value, %Connection{private: private} = conn) do
-          %Connection{conn | private: Keyword.put(private, key, value)}
-        end
+      @doc false
+      def put_private(key, value, connection(private: private) = conn) do
+        connection(conn, private: Keyword.put(private, key, value))
+      end
 
-        @doc false
-        def main(%Connection{main: main}) do
-          main
-        end
+      @doc false
+      def main(connection(main: main)) do
+        main
+      end
 
-        ## Fetch
+      ## Fetch
 
-        @doc false
-        def fetchable(atom, fun, %Connection{fetchable: fetchable} = conn) when is_atom(atom) and is_function(fun, 1) do
-          %Connection{conn | fetchable: [{ atom, fun }|fetchable]}
-        end
+      @doc false
+      def fetchable(atom, fun, connection(fetchable: fetchable) = conn) when is_atom(atom) and is_function(fun, 1) do
+        connection(conn, fetchable: [{ atom, fun }|fetchable])
+      end
 
-        ## Request
+      ## Request
 
-        @doc false
-        def params(%Connection{params: nil}) do
-          raise Dynamo.Connection.UnfetchedError, aspect: :params
-        end
+      @doc false
+      def params(connection(params: nil)) do
+        raise Dynamo.Connection.UnfetchedError, aspect: :params
+      end
 
-        @doc false
-        def params(%Connection{params: params}) do
-          params
-        end
+      @doc false
+      def params(connection(params: params)) do
+        params
+      end
 
-        @doc false
-        def route_params(%Connection{route_params: route_params}) do
-          route_params
-        end
+      @doc false
+      def route_params(connection(route_params: route_params)) do
+        route_params
+      end
 
-        @doc false
-        def route_params(new, %Connection{params: nil, route_params: route_params} = conn) do
-          %Connection{conn | route_params: route_params ++ new}
-        end
+      @doc false
+      def route_params(new, connection(params: nil, route_params: route_params) = conn) do
+        connection(conn, route_params: route_params ++ new)
+      end
 
-        @doc false
-        def route_params(new, %Connection{params: params, route_params: route_params} = conn) do
-          %Connection{conn | route_params: route_params ++ new, params: Dict.merge(params, new)}
-        end
+      @doc false
+      def route_params(new, connection(params: params, route_params: route_params) = conn) do
+        connection(conn, route_params: route_params ++ new, params: Dict.merge(params, new))
+      end
 
-        @doc false
-        def method(%Connection{method: method}) do
-          method
-        end
+      @doc false
+      def method(connection(method: method)) do
+        method
+      end
 
-        @doc false
-        def method(method, conn) when is_binary(method) do
-          %Connection{conn | method: method}
-        end
+      @doc false
+      def method(method, conn) when is_binary(method) do
+        connection(conn, method: method)
+      end
 
-        @doc false
-        def req_headers(%Connection{req_headers: nil}) do
-          raise Dynamo.Connection.UnfetchedError, aspect: :req_headers
-        end
+      @doc false
+      def req_headers(connection(req_headers: nil)) do
+        raise Dynamo.Connection.UnfetchedError, aspect: :req_headers
+      end
 
-        @doc false
-        def req_headers(%Connection{req_headers: req_headers}) do
-          req_headers
-        end
+      @doc false
+      def req_headers(connection(req_headers: req_headers)) do
+        req_headers
+      end
 
-        @doc false
-        def req_body(%Connection{req_body: nil}) do
-          raise Dynamo.Connection.UnfetchedError, aspect: :req_body
-        end
+      @doc false
+      def req_body(connection(req_body: nil)) do
+        raise Dynamo.Connection.UnfetchedError, aspect: :req_body
+      end
 
-        @doc false
-        def req_body(%Connection{req_body: req_body}) do
-          req_body
-        end
+      @doc false
+      def req_body(connection(req_body: req_body)) do
+        req_body
+      end
 
-        ## Cookies
+      ## Cookies
 
-        @doc false
-        def req_cookies(%Connection{req_cookies: nil}) do
-          raise Dynamo.Connection.UnfetchedError, aspect: :cookies
-        end
+      @doc false
+      def req_cookies(connection(req_cookies: nil)) do
+        raise Dynamo.Connection.UnfetchedError, aspect: :cookies
+      end
 
-        @doc false
-        def req_cookies(%Connection{req_cookies: req_cookies}) do
-          req_cookies
-        end
+      @doc false
+      def req_cookies(connection(req_cookies: req_cookies)) do
+        req_cookies
+      end
 
-        @doc false
-        def resp_cookies(%Connection{resp_cookies: resp_cookies}) do
-          resp_cookies
-        end
+      @doc false
+      def resp_cookies(connection(resp_cookies: resp_cookies)) do
+        resp_cookies
+      end
 
-        @doc false
-        def put_resp_cookie(key, value, opts, %Connection{resp_cookies: resp_cookies} = conn)
-            when is_binary(key) and (is_binary(value) or nil?(value)) and is_list(opts) do
-          resp_cookies = List.keydelete(resp_cookies, key, 0)
-          %Connection{conn, resp_cookies: [{ key, value, opts }|resp_cookies]}
-        end
+      @doc false
+      def put_resp_cookie(key, value, opts, connection(resp_cookies: resp_cookies) = conn)
+          when is_binary(key) and (is_binary(value) or nil?(value)) and is_list(opts) do
+        resp_cookies = List.keydelete(resp_cookies, key, 0)
+        connection(conn, resp_cookies: [{ key, value, opts }|resp_cookies])
+      end
 
-        ## Paths
+      ## Paths
 
-        @doc false
-        def path_info_segments(%Connection{path_info_segments: segments}) do
-          segments
-        end
+      @doc false
+      def path_info_segments(connection(path_info_segments: segments)) do
+        segments
+      end
 
-        @doc false
-        def path_info(%Connection{path_info_segments: segments}) do
-          to_path segments
-        end
+      @doc false
+      def path_info(connection(path_info_segments: segments)) do
+        to_path segments
+      end
 
-        @doc false
-        def script_name_segments(%Connection{script_name_segments: segments}) do
-          segments
-        end
+      @doc false
+      def script_name_segments(connection(script_name_segments: segments)) do
+        segments
+      end
 
-        @doc false
-        def script_name(%Connection{script_name_segments: segments}) do
-          to_path segments
-        end
+      @doc false
+      def script_name(connection(script_name_segments: segments)) do
+        to_path segments
+      end
 
-        @doc false
-        def forward_to(segments, _target,
-            %Connection{path_info_segments: path, script_name_segments: script} = conn) do
-          { prefix, ^segments } = Enum.split path, length(path) - length(segments)
+      @doc false
+      def forward_to(segments, _target,
+          connection(path_info_segments: path, script_name_segments: script) = conn) do
+        { prefix, ^segments } = Enum.split path, length(path) - length(segments)
 
-          %Connection{conn |
-            path_info_segments: segments,
-            script_name_segments: script ++ prefix
-          }
-        end
+        connection(conn,
+          path_info_segments: segments,
+          script_name_segments: script ++ prefix
+        )
+      end
 
-        defp to_path(segments) do
-          "/" <> Enum.join(segments, "/")
-        end
+      defp to_path(segments) do
+        "/" <> Enum.join(segments, "/")
+      end
 
-        ## Response
+      ## Response
 
-        @doc false
-        def status(%Connection{status: status}) do
-          status
-        end
+      @doc false
+      def status(connection(status: status)) do
+        status
+      end
 
-        @doc false
-        def status(status, %Connection{state: state} = conn) when
-            is_integer(status) and state in [:unset, :set, :sendfile, :chunked] do
-          %Connection{conn | status: status, state: :set}
-        end
+      @doc false
+      def status(status, connection(state: state) = conn) when
+          is_integer(status) and state in [:unset, :set, :sendfile, :chunked] do
+        connection(conn, status: status, state: :set)
+      end
 
-        @doc false
-        def resp_body(%Connection{resp_body: resp_body}) do
-          resp_body
-        end
+      @doc false
+      def resp_body(connection(resp_body: resp_body)) do
+        resp_body
+      end
 
-        @doc false
-        def resp_body(body, %Connection{status: status, state: state} = conn) when state in [:unset, :set] do
-          %Connection{conn |
-            status: status || 200,
-            resp_body: body,
-            state: :set}
-        end
+      @doc false
+      def resp_body(body, connection(status: status, state: state) = conn) when state in [:unset, :set] do
+        connection(conn,
+          status: status || 200,
+          resp_body: body,
+          state: :set)
+      end
 
-        @doc false
-        def resp_content_type(%Connection{resp_content_type: resp_content_type}) do
-          resp_content_type
-        end
+      @doc false
+      def resp_content_type(connection(resp_content_type: resp_content_type)) do
+        resp_content_type
+      end
 
-        @doc false
-        def resp_content_type(resp_content_type, conn) when is_binary(resp_content_type) do
-          %Connection{conn | resp_content_type: resp_content_type}
-        end
+      @doc false
+      def resp_content_type(resp_content_type, conn) when is_binary(resp_content_type) do
+        connection(conn, resp_content_type: resp_content_type)
+      end
 
-        @doc false
-        def resp_charset(%Connection{resp_charset: resp_charset}) do
-          resp_charset
-        end
+      @doc false
+      def resp_charset(connection(resp_charset: resp_charset)) do
+        resp_charset
+      end
 
-        @doc false
-        def resp_charset(resp_charset, conn) when is_binary(resp_charset) do
-          %Connection{conn | resp_charset: resp_charset}
-        end
+      @doc false
+      def resp_charset(resp_charset, conn) when is_binary(resp_charset) do
+        connection(conn, resp_charset: resp_charset)
+      end
 
-        @doc false
-        def resp(status, body, %Connection{state: state} = conn)
-            when is_integer(status) and state in [:unset, :set] do
-          %Connection{conn |
-            status: status,
-            resp_body: body,
-            state: :set
-          }
-        end
+      @doc false
+      def resp(status, body, connection(state: state) = conn)
+          when is_integer(status) and state in [:unset, :set] do
+        connection(conn,
+          status: status,
+          resp_body: body,
+          state: :set
+        )
+      end
 
-        @doc false
-        def send(%Connection{status: status, resp_body: body} = conn) do
-          send(status, body, conn)
-        end
+      @doc false
+      def send(connection(status: status, resp_body: body) = conn) do
+        send(status, body, conn)
+      end
 
-        @doc false
-        def state(%Connection{state: state}) do
-          state
-        end
+      @doc false
+      def state(connection(state: state)) do
+        state
+      end
 
-        @doc false
-        def resp_headers(%Connection{resp_headers: resp_headers}) do
-          resp_headers
-        end
+      @doc false
+      def resp_headers(connection(resp_headers: resp_headers)) do
+        resp_headers
+      end
 
-        @doc false
-        def put_resp_header(key, value, %Connection{resp_headers: resp_headers} = conn) do
-          %Connection{conn, resp_headers: Binary.Dict.put(resp_headers, key, to_string(value))}
-        end
+      @doc false
+      def put_resp_header(key, value, connection(resp_headers: resp_headers) = conn) do
+        connection(conn, resp_headers: Binary.Dict.put(resp_headers, key, to_string(value)))
+      end
 
-        @doc false
-        def delete_resp_header(key, %Connection{resp_headers: resp_headers} = conn) do
-          %Connection{conn | resp_headers: Binary.Dict.delete(resp_headers, key)}
-        end
+      @doc false
+      def delete_resp_header(key, connection(resp_headers: resp_headers) = conn) do
+        connection(conn, resp_headers: Binary.Dict.delete(resp_headers, key))
+      end
 
-        # Callbacks
+      # Callbacks
 
-        @doc false
-        def before_send(fun, %Connection{before_send: before_send} = conn) when is_function(fun) do
-          %Connection{conn | before_send: [fun|before_send]}
-        end
+      @doc false
+      def before_send(fun, connection(before_send: before_send) = conn) when is_function(fun) do
+        connection(conn, before_send: [fun|before_send])
+      end
 
-        defp run_before_send(%Connection{before_send: before_send} = conn) do
-          Enum.reduce Enum.reverse(before_send), conn, fn(fun, c) -> fun.(c) end
-        end
+      defp run_before_send(connection(before_send: before_send) = conn) do
+        Enum.reduce Enum.reverse(before_send), conn, fn(fun, c) -> fun.(c) end
       end
     end
 

--- a/lib/dynamo/connection/query_parser.ex
+++ b/lib/dynamo/connection/query_parser.ex
@@ -97,14 +97,14 @@ defmodule Dynamo.Connection.QueryParser do
   # continue looping.
   defp assign_parts([key|t], acc, value) do
     child =
-      case Dict.get(acc, key) do
+      case Binary.Dict.get(acc, key) do
         current when is_record(current, Binary.Dict) -> current
         nil -> Binary.Dict.new
         _   -> raise ParseError, message: "expected dict at #{key}"
       end
 
     value = assign_parts(t, child, value)
-    Dict.put(acc, key, value)
+    Binary.Dict.put(acc, key, value)
   end
 
   defp assign_list_parts([], value), do: value

--- a/lib/dynamo/connection/test.ex
+++ b/lib/dynamo/connection/test.ex
@@ -175,7 +175,7 @@ defmodule Dynamo.Connection.Test do
 
   def fetch(:params, connection(query_string: query_string, params: nil, route_params: route_params, fetched: fetched) = conn) do
     params = Dynamo.Connection.QueryParser.parse(query_string)
-    params = Dict.merge(params, route_params)
+    params = Binary.Dict.merge(params, route_params)
     connection(conn, params: params, fetched: [:params|fetched])
   end
 
@@ -302,7 +302,7 @@ defmodule Dynamo.Connection.Test do
   Sets the cookies to be read by the request.
   """
   def put_req_cookie(key, value, connection(raw_req_cookies: cookies) = conn) do
-    connection(conn, raw_req_cookies: Dict.put(cookies, key, value))
+    connection(conn, raw_req_cookies: Binary.Dict.put(cookies, key, value))
   end
 
   @doc """
@@ -310,14 +310,14 @@ defmodule Dynamo.Connection.Test do
   Both `key` and `value` are converted to binary.
   """
   def put_req_header(key, value, connection(raw_req_headers: raw_req_headers) = conn) do
-    connection(conn, raw_req_headers: Dict.put(raw_req_headers, String.downcase(key), to_string(value)))
+    connection(conn, raw_req_headers: Binary.Dict.put(raw_req_headers, String.downcase(key), to_string(value)))
   end
 
   @doc """
   Deletes a request header.
   """
   def delete_req_header(key, connection(raw_req_headers: raw_req_headers) = conn) do
-    connection(conn, raw_req_headers: Dict.delete(raw_req_headers, String.downcase(key)))
+    connection(conn, raw_req_headers: Binary.Dict.delete(raw_req_headers, String.downcase(key)))
   end
 end
 

--- a/lib/dynamo/connection/test.ex
+++ b/lib/dynamo/connection/test.ex
@@ -4,11 +4,11 @@ defmodule Dynamo.Connection.Test do
   Check `Dynamo.Connection` for documentation of all available callbacks.
 
   Note that, besides the functions required by `Dynamo.Connection`,
-  this connection also implements a couple extra functions, like
+  this Connection also implements a couple extra functions, like
   `sent_body/1`, to retrieve the sent body, and `fetched/1`, to
   retrieve fetched aspects, which are useful for testing.
 
-  Although a new connection can be created via:
+  Although a new Connection can be created via:
 
       Dynamo.Connection.Test.new(verb, path, body, peer)
 
@@ -25,16 +25,16 @@ defmodule Dynamo.Connection.Test do
       :path, :path_segments, :sent_body, :original_method, :scheme, :port, :peer ]
 
   @doc """
-  Initializes a connection to be used in tests.
+  Initializes a Connection to be used in tests.
   """
   def new(method, path, body \\ "") do
-    connection(
+    %Connection{
       main: Dynamo.under_test,
       raw_req_cookies: Binary.Dict.new(),
       raw_req_headers: Binary.Dict.new([{ "host", "127.0.0.1" }]),
       scheme: :http,
       port: 80
-    ).recycle.req(method, path, body)
+    }.recycle.req(method, path, body)
   end
 
   ## Request API
@@ -45,51 +45,51 @@ defmodule Dynamo.Connection.Test do
   end
 
   @doc false
-  def original_method(connection(original_method: method)) do
+  def original_method(%Connection{original_method: method}) do
     method
   end
 
   @doc false
-  def query_string(connection(query_string: query_string)) do
+  def query_string(%Connection{query_string: query_string}) do
     query_string
   end
 
   @doc false
-  def path_segments(connection(path_segments: path_segments)) do
+  def path_segments(%Connection{path_segments: path_segments}) do
     path_segments
   end
 
   @doc false
-  def path(connection(path: path)) do
+  def path(%Connection{path: path}) do
     path
   end
 
   @doc false
-  def scheme(connection(scheme: scheme)) do
+  def scheme(%Connection{scheme: scheme}) do
     scheme
   end
 
   @doc false
-  def port(connection(port: port)) do
+  def port(%Connection{port: port}) do
     port
   end
 
   @doc false
-  def peer(connection(peer: peer)) do
+  def peer(%Connection{peer: peer}) do
     peer
   end
 
   def peer(peer, conn) do
-    connection(conn, peer: peer)
+    %Connection{conn | peer: peer}
   end
 
   @doc false
-  def host(connection(raw_req_headers: headers)) do
+  def host(%Connection{raw_req_headers: headers}) do
     hd(:binary.split(headers["host"], ":"))
   end
 
   @doc false
-  def host_url(connection(scheme: scheme, raw_req_headers: headers)) do
+  def host_url(%Connection{scheme: scheme, raw_req_headers: headers}) do
     "#{scheme}://#{headers["host"]}"
   end
 
@@ -109,54 +109,54 @@ defmodule Dynamo.Connection.Test do
   end
 
   @doc false
-  def send(status, body, connection(state: state) = conn) when is_integer(status)
+  def send(status, body, %Connection{state: state} = conn) when is_integer(status)
       and state in [:unset, :set] and is_binary(body) do
     send self, @send_flag
 
-    conn = run_before_send(connection(conn, state: :set, status: status, resp_body: body))
-    connection(resp_body: body) = conn
+    conn = run_before_send(%Connection{conn | state: :set, status: status, resp_body: body})
+    %Connection{resp_body: body} = conn
 
-    connection(conn,
+    %Connection{conn |
       state: :sent,
       sent_body: check_sent_body(conn, body),
       resp_body: nil
-    )
+    }
   end
 
   @doc false
-  def send_chunked(status, connection(state: state) = conn) when is_integer(status)
+  def send_chunked(status, %Connection{state: state} = conn) when is_integer(status)
       and state in [:unset, :set] do
     send self, @send_flag
-    conn = run_before_send(connection(conn, state: :chunked, status: status))
+    conn = run_before_send(%Connection{conn | state: :chunked, status: status})
 
-    connection(conn,
+    %Connection{conn |
       sent_body: "",
       resp_body: nil
-    )
+    }
   end
 
   @doc false
-  def chunk(body, connection(state: state, sent_body: sent) = conn) when state == :chunked do
-    { :ok, connection(conn, sent_body: check_sent_body(conn, sent <> body)) }
+  def chunk(body, %Connection{state: state, sent_body: sent} = conn) when state == :chunked do
+    { :ok, %Connection{conn, sent_body: check_sent_body(conn, sent <> body)} }
   end
 
-  defp check_sent_body(connection(original_method: "HEAD"), _body), do: ""
+  defp check_sent_body(%Connection{original_method: "HEAD"}, _body), do: ""
   defp check_sent_body(_conn, body),                                do: body
 
   @doc false
   def sendfile(status, path, conn) when is_integer(status) and is_binary(path) do
     send self, @send_flag
-    conn = run_before_send(connection(conn, state: :sendfile, status: status))
+    conn = run_before_send(%Connection{conn, state: :sendfile, status: status})
 
-    connection(conn,
+    %Connection{conn |
       state: :sent,
       sent_body: check_sent_body(conn, File.read!(path)),
       resp_body: nil
-    )
+    }
   end
 
   @doc false
-  def sent_body(connection(sent_body: sent_body)) do
+  def sent_body(%Connection{sent_body: sent_body}) do
     sent_body
   end
 
@@ -167,34 +167,35 @@ defmodule Dynamo.Connection.Test do
     Enum.reduce list, conn, fn(item, acc) -> acc.fetch(item) end
   end
 
-  def fetch(:headers, connection(raw_req_headers: raw_req_headers, req_headers: nil, fetched: fetched) = conn) do
-    connection(conn,
+  def fetch(:headers, %Connection{raw_req_headers: raw_req_headers, req_headers: nil, fetched: fetched} = conn) do
+    %Connection{conn |
       fetched: [:headers|fetched],
-      req_headers: raw_req_headers)
+      req_headers: raw_req_headers
+    }
   end
 
-  def fetch(:params, connection(query_string: query_string, params: nil, route_params: route_params, fetched: fetched) = conn) do
+  def fetch(:params, %Connection{query_string: query_string, params: nil, route_params: route_params, fetched: fetched} = conn) do
     params = Dynamo.Connection.QueryParser.parse(query_string)
     params = Dict.merge(params, route_params)
-    connection(conn, params: params, fetched: [:params|fetched])
+    %Connection{conn | params: params, fetched: [:params|fetched]}
   end
 
-  def fetch(:cookies, connection(raw_req_cookies: raw_req_cookies, req_cookies: nil, fetched: fetched) = conn) do
-    connection(conn, req_cookies: raw_req_cookies, fetched: [:cookies|fetched])
+  def fetch(:cookies, %Connection{raw_req_cookies: raw_req_cookies, req_cookies: nil, fetched: fetched} = conn) do
+    %Connection{conn | req_cookies: raw_req_cookies, fetched: [:cookies|fetched]}
   end
 
-  def fetch(:body, connection(raw_req_body: req_body, req_body: nil, fetched: fetched) = conn) do
-    connection(conn, req_body: req_body, fetched: [:body|fetched])
+  def fetch(:body, %Connection{raw_req_body: req_body, req_body: nil, fetched: fetched} = conn) do
+    %Connection{conn | req_body: req_body, fetched: [:body|fetched]}
   end
 
   def fetch(aspect, conn) when aspect in [:params, :cookies, :body, :headers] do
     conn
   end
 
-  def fetch(aspect, connection(fetchable: fetchable, fetched: fetched) = conn) when is_atom(aspect) do
+  def fetch(aspect, %Connection{fetchable: fetchable, fetched: fetched} = conn) when is_atom(aspect) do
     case Keyword.get(fetchable, aspect) do
       nil -> raise Dynamo.Connection.UnknownFetchError, aspect: aspect
-      fun -> connection(fun.(conn), fetched: [aspect|fetched])
+      fun -> %Connection{fun.(conn) | fetched: [aspect|fetched]}
     end
   end
 
@@ -204,11 +205,11 @@ defmodule Dynamo.Connection.Test do
   Sets the main module under test.
   """
   def main(main, conn) do
-    connection(conn, main: main)
+    %Connection{conn | main: main}
   end
 
   @doc """
-  Prepares the connection to do a new request on the
+  Prepares the Connection to do a new request on the
   given `path` with the given `method` and `body`.
 
   This can be considered the counter-part of recycle
@@ -222,7 +223,7 @@ defmodule Dynamo.Connection.Test do
     # Clear up any existing send flag
     flush_send
 
-    conn = connection(conn,
+    conn = %Connection{conn |
       method: method,
       original_method: method,
       params: nil,
@@ -233,18 +234,19 @@ defmodule Dynamo.Connection.Test do
       raw_req_body: body,
       req_body: nil,
       route_params: [],
-      script_name_segments: [])
+      script_name_segments: []
+    }
 
     if uri.authority do
       conn = conn.put_req_header "host", uri.authority
     end
 
     if uri.scheme do
-      conn = connection(conn, scheme: uri.scheme)
+      conn = %Connection{conn | scheme: uri.scheme}
     end
 
     if uri.port do
-      conn = connection(conn, port: uri.port)
+      conn = %Connection{conn | port: uri.port}
     end
 
     conn
@@ -259,16 +261,16 @@ defmodule Dynamo.Connection.Test do
   end
 
   @doc """
-  Recycles the connection to it can be used in a subsequent requests.
+  Recycles the Connection to it can be used in a subsequent requests.
 
-  Reclycing the connection resets all assigns, privates and other
+  Reclycing the Connection resets all assigns, privates and other
   response information but keeps mostly of request information intact.
 
   Particularly, cookies sent in the response are moved to the request,
   so they can be used in upcoming requests.
   """
-  def recycle(connection(resp_cookies: resp_cookies) = conn) do
-    conn = connection(conn,
+  def recycle(%Connection{resp_cookies: resp_cookies} = conn) do
+    conn = %Connection{conn |
       assigns: [],
       before_send: Dynamo.Connection.default_before_send,
       fetchable: [],
@@ -284,7 +286,7 @@ defmodule Dynamo.Connection.Test do
       sent_body: nil,
       state: :unset,
       status: nil
-    )
+    }
 
     Enum.reduce resp_cookies, conn, fn({ key, value, _opts }, acc) ->
       acc.put_req_cookie(key, value)
@@ -294,30 +296,30 @@ defmodule Dynamo.Connection.Test do
   @doc """
   Returns all fetched aspects during a request.
   """
-  def fetched(connection(fetched: fetched)) do
+  def fetched(%Connection{fetched: fetched}) do
     fetched
   end
 
   @doc """
   Sets the cookies to be read by the request.
   """
-  def put_req_cookie(key, value, connection(raw_req_cookies: cookies) = conn) do
-    connection(conn, raw_req_cookies: Dict.put(cookies, key, value))
+  def put_req_cookie(key, value, %Connection{raw_req_cookies: cookies} = conn) do
+    %Connection{conn | raw_req_cookies: Dict.put(cookies, key, value)}
   end
 
   @doc """
   Sets a request header, overriding any previous value.
   Both `key` and `value` are converted to binary.
   """
-  def put_req_header(key, value, connection(raw_req_headers: raw_req_headers) = conn) do
-    connection(conn, raw_req_headers: Dict.put(raw_req_headers, String.downcase(key), to_string(value)))
+  def put_req_header(key, value, %Connection{raw_req_headers: raw_req_headers} = conn) do
+    %Connection{conn | raw_req_headers: Dict.put(raw_req_headers, String.downcase(key), to_string(value))}
   end
 
   @doc """
   Deletes a request header.
   """
-  def delete_req_header(key, connection(raw_req_headers: raw_req_headers) = conn) do
-    connection(conn, raw_req_headers: Dict.delete(raw_req_headers, String.downcase(key)))
+  def delete_req_header(key, %Connection{raw_req_headers: raw_req_headers} = conn) do
+    %Connection{conn, raw_req_headers: Dict.delete(raw_req_headers, String.downcase(key))}
   end
 end
 

--- a/lib/dynamo/connection/test.ex
+++ b/lib/dynamo/connection/test.ex
@@ -4,11 +4,11 @@ defmodule Dynamo.Connection.Test do
   Check `Dynamo.Connection` for documentation of all available callbacks.
 
   Note that, besides the functions required by `Dynamo.Connection`,
-  this Connection also implements a couple extra functions, like
+  this connection also implements a couple extra functions, like
   `sent_body/1`, to retrieve the sent body, and `fetched/1`, to
   retrieve fetched aspects, which are useful for testing.
 
-  Although a new Connection can be created via:
+  Although a new connection can be created via:
 
       Dynamo.Connection.Test.new(verb, path, body, peer)
 
@@ -25,16 +25,16 @@ defmodule Dynamo.Connection.Test do
       :path, :path_segments, :sent_body, :original_method, :scheme, :port, :peer ]
 
   @doc """
-  Initializes a Connection to be used in tests.
+  Initializes a connection to be used in tests.
   """
   def new(method, path, body \\ "") do
-    %Connection{
+    connection(
       main: Dynamo.under_test,
       raw_req_cookies: Binary.Dict.new(),
       raw_req_headers: Binary.Dict.new([{ "host", "127.0.0.1" }]),
       scheme: :http,
       port: 80
-    }.recycle.req(method, path, body)
+    ).recycle.req(method, path, body)
   end
 
   ## Request API
@@ -45,51 +45,51 @@ defmodule Dynamo.Connection.Test do
   end
 
   @doc false
-  def original_method(%Connection{original_method: method}) do
+  def original_method(connection(original_method: method)) do
     method
   end
 
   @doc false
-  def query_string(%Connection{query_string: query_string}) do
+  def query_string(connection(query_string: query_string)) do
     query_string
   end
 
   @doc false
-  def path_segments(%Connection{path_segments: path_segments}) do
+  def path_segments(connection(path_segments: path_segments)) do
     path_segments
   end
 
   @doc false
-  def path(%Connection{path: path}) do
+  def path(connection(path: path)) do
     path
   end
 
   @doc false
-  def scheme(%Connection{scheme: scheme}) do
+  def scheme(connection(scheme: scheme)) do
     scheme
   end
 
   @doc false
-  def port(%Connection{port: port}) do
+  def port(connection(port: port)) do
     port
   end
 
   @doc false
-  def peer(%Connection{peer: peer}) do
+  def peer(connection(peer: peer)) do
     peer
   end
 
   def peer(peer, conn) do
-    %Connection{conn | peer: peer}
+    connection(conn, peer: peer)
   end
 
   @doc false
-  def host(%Connection{raw_req_headers: headers}) do
+  def host(connection(raw_req_headers: headers)) do
     hd(:binary.split(headers["host"], ":"))
   end
 
   @doc false
-  def host_url(%Connection{scheme: scheme, raw_req_headers: headers}) do
+  def host_url(connection(scheme: scheme, raw_req_headers: headers)) do
     "#{scheme}://#{headers["host"]}"
   end
 
@@ -109,54 +109,54 @@ defmodule Dynamo.Connection.Test do
   end
 
   @doc false
-  def send(status, body, %Connection{state: state} = conn) when is_integer(status)
+  def send(status, body, connection(state: state) = conn) when is_integer(status)
       and state in [:unset, :set] and is_binary(body) do
     send self, @send_flag
 
-    conn = run_before_send(%Connection{conn | state: :set, status: status, resp_body: body})
-    %Connection{resp_body: body} = conn
+    conn = run_before_send(connection(conn, state: :set, status: status, resp_body: body))
+    connection(resp_body: body) = conn
 
-    %Connection{conn |
+    connection(conn,
       state: :sent,
       sent_body: check_sent_body(conn, body),
       resp_body: nil
-    }
+    )
   end
 
   @doc false
-  def send_chunked(status, %Connection{state: state} = conn) when is_integer(status)
+  def send_chunked(status, connection(state: state) = conn) when is_integer(status)
       and state in [:unset, :set] do
     send self, @send_flag
-    conn = run_before_send(%Connection{conn | state: :chunked, status: status})
+    conn = run_before_send(connection(conn, state: :chunked, status: status))
 
-    %Connection{conn |
+    connection(conn,
       sent_body: "",
       resp_body: nil
-    }
+    )
   end
 
   @doc false
-  def chunk(body, %Connection{state: state, sent_body: sent} = conn) when state == :chunked do
-    { :ok, %Connection{conn, sent_body: check_sent_body(conn, sent <> body)} }
+  def chunk(body, connection(state: state, sent_body: sent) = conn) when state == :chunked do
+    { :ok, connection(conn, sent_body: check_sent_body(conn, sent <> body)) }
   end
 
-  defp check_sent_body(%Connection{original_method: "HEAD"}, _body), do: ""
+  defp check_sent_body(connection(original_method: "HEAD"), _body), do: ""
   defp check_sent_body(_conn, body),                                do: body
 
   @doc false
   def sendfile(status, path, conn) when is_integer(status) and is_binary(path) do
     send self, @send_flag
-    conn = run_before_send(%Connection{conn, state: :sendfile, status: status})
+    conn = run_before_send(connection(conn, state: :sendfile, status: status))
 
-    %Connection{conn |
+    connection(conn,
       state: :sent,
       sent_body: check_sent_body(conn, File.read!(path)),
       resp_body: nil
-    }
+    )
   end
 
   @doc false
-  def sent_body(%Connection{sent_body: sent_body}) do
+  def sent_body(connection(sent_body: sent_body)) do
     sent_body
   end
 
@@ -167,35 +167,34 @@ defmodule Dynamo.Connection.Test do
     Enum.reduce list, conn, fn(item, acc) -> acc.fetch(item) end
   end
 
-  def fetch(:headers, %Connection{raw_req_headers: raw_req_headers, req_headers: nil, fetched: fetched} = conn) do
-    %Connection{conn |
+  def fetch(:headers, connection(raw_req_headers: raw_req_headers, req_headers: nil, fetched: fetched) = conn) do
+    connection(conn,
       fetched: [:headers|fetched],
-      req_headers: raw_req_headers
-    }
+      req_headers: raw_req_headers)
   end
 
-  def fetch(:params, %Connection{query_string: query_string, params: nil, route_params: route_params, fetched: fetched} = conn) do
+  def fetch(:params, connection(query_string: query_string, params: nil, route_params: route_params, fetched: fetched) = conn) do
     params = Dynamo.Connection.QueryParser.parse(query_string)
     params = Dict.merge(params, route_params)
-    %Connection{conn | params: params, fetched: [:params|fetched]}
+    connection(conn, params: params, fetched: [:params|fetched])
   end
 
-  def fetch(:cookies, %Connection{raw_req_cookies: raw_req_cookies, req_cookies: nil, fetched: fetched} = conn) do
-    %Connection{conn | req_cookies: raw_req_cookies, fetched: [:cookies|fetched]}
+  def fetch(:cookies, connection(raw_req_cookies: raw_req_cookies, req_cookies: nil, fetched: fetched) = conn) do
+    connection(conn, req_cookies: raw_req_cookies, fetched: [:cookies|fetched])
   end
 
-  def fetch(:body, %Connection{raw_req_body: req_body, req_body: nil, fetched: fetched} = conn) do
-    %Connection{conn | req_body: req_body, fetched: [:body|fetched]}
+  def fetch(:body, connection(raw_req_body: req_body, req_body: nil, fetched: fetched) = conn) do
+    connection(conn, req_body: req_body, fetched: [:body|fetched])
   end
 
   def fetch(aspect, conn) when aspect in [:params, :cookies, :body, :headers] do
     conn
   end
 
-  def fetch(aspect, %Connection{fetchable: fetchable, fetched: fetched} = conn) when is_atom(aspect) do
+  def fetch(aspect, connection(fetchable: fetchable, fetched: fetched) = conn) when is_atom(aspect) do
     case Keyword.get(fetchable, aspect) do
       nil -> raise Dynamo.Connection.UnknownFetchError, aspect: aspect
-      fun -> %Connection{fun.(conn) | fetched: [aspect|fetched]}
+      fun -> connection(fun.(conn), fetched: [aspect|fetched])
     end
   end
 
@@ -205,11 +204,11 @@ defmodule Dynamo.Connection.Test do
   Sets the main module under test.
   """
   def main(main, conn) do
-    %Connection{conn | main: main}
+    connection(conn, main: main)
   end
 
   @doc """
-  Prepares the Connection to do a new request on the
+  Prepares the connection to do a new request on the
   given `path` with the given `method` and `body`.
 
   This can be considered the counter-part of recycle
@@ -223,7 +222,7 @@ defmodule Dynamo.Connection.Test do
     # Clear up any existing send flag
     flush_send
 
-    conn = %Connection{conn |
+    conn = connection(conn,
       method: method,
       original_method: method,
       params: nil,
@@ -234,19 +233,18 @@ defmodule Dynamo.Connection.Test do
       raw_req_body: body,
       req_body: nil,
       route_params: [],
-      script_name_segments: []
-    }
+      script_name_segments: [])
 
     if uri.authority do
       conn = conn.put_req_header "host", uri.authority
     end
 
     if uri.scheme do
-      conn = %Connection{conn | scheme: uri.scheme}
+      conn = connection(conn, scheme: uri.scheme)
     end
 
     if uri.port do
-      conn = %Connection{conn | port: uri.port}
+      conn = connection(conn, port: uri.port)
     end
 
     conn
@@ -261,16 +259,16 @@ defmodule Dynamo.Connection.Test do
   end
 
   @doc """
-  Recycles the Connection to it can be used in a subsequent requests.
+  Recycles the connection to it can be used in a subsequent requests.
 
-  Reclycing the Connection resets all assigns, privates and other
+  Reclycing the connection resets all assigns, privates and other
   response information but keeps mostly of request information intact.
 
   Particularly, cookies sent in the response are moved to the request,
   so they can be used in upcoming requests.
   """
-  def recycle(%Connection{resp_cookies: resp_cookies} = conn) do
-    conn = %Connection{conn |
+  def recycle(connection(resp_cookies: resp_cookies) = conn) do
+    conn = connection(conn,
       assigns: [],
       before_send: Dynamo.Connection.default_before_send,
       fetchable: [],
@@ -286,7 +284,7 @@ defmodule Dynamo.Connection.Test do
       sent_body: nil,
       state: :unset,
       status: nil
-    }
+    )
 
     Enum.reduce resp_cookies, conn, fn({ key, value, _opts }, acc) ->
       acc.put_req_cookie(key, value)
@@ -296,30 +294,30 @@ defmodule Dynamo.Connection.Test do
   @doc """
   Returns all fetched aspects during a request.
   """
-  def fetched(%Connection{fetched: fetched}) do
+  def fetched(connection(fetched: fetched)) do
     fetched
   end
 
   @doc """
   Sets the cookies to be read by the request.
   """
-  def put_req_cookie(key, value, %Connection{raw_req_cookies: cookies} = conn) do
-    %Connection{conn | raw_req_cookies: Dict.put(cookies, key, value)}
+  def put_req_cookie(key, value, connection(raw_req_cookies: cookies) = conn) do
+    connection(conn, raw_req_cookies: Dict.put(cookies, key, value))
   end
 
   @doc """
   Sets a request header, overriding any previous value.
   Both `key` and `value` are converted to binary.
   """
-  def put_req_header(key, value, %Connection{raw_req_headers: raw_req_headers} = conn) do
-    %Connection{conn | raw_req_headers: Dict.put(raw_req_headers, String.downcase(key), to_string(value))}
+  def put_req_header(key, value, connection(raw_req_headers: raw_req_headers) = conn) do
+    connection(conn, raw_req_headers: Dict.put(raw_req_headers, String.downcase(key), to_string(value)))
   end
 
   @doc """
   Deletes a request header.
   """
-  def delete_req_header(key, %Connection{raw_req_headers: raw_req_headers} = conn) do
-    %Connection{conn, raw_req_headers: Dict.delete(raw_req_headers, String.downcase(key))}
+  def delete_req_header(key, connection(raw_req_headers: raw_req_headers) = conn) do
+    connection(conn, raw_req_headers: Dict.delete(raw_req_headers, String.downcase(key)))
   end
 end
 

--- a/lib/dynamo/cowboy/body_parser.ex
+++ b/lib/dynamo/cowboy/body_parser.ex
@@ -33,13 +33,13 @@ defmodule Dynamo.Cowboy.BodyParser do
         { body, req } = parse_multipart_body(R.part_body(req), "")
         parse_multipart(R.part(req), tmp_dir, [{ name, body }|acc])
 
-      { name, Dynamo.Connection.File[] = file } ->
+      { name, %Dynamo.Connection.File{} = file } ->
         tmp_dir = get_tmp_dir(tmp_dir)
 
         { path, { :ok, req } } = Dynamo.Connection.Utils.random_file("uploaded",
           tmp_dir, &parse_multipart_file(R.part_body(req), &1))
 
-        parse_multipart(R.part(req), tmp_dir, [{ name, file.path(path) }|acc])
+        parse_multipart(R.part(req), tmp_dir, [{ name, %Dynamo.Connection.File{file | path: path} }|acc])
 
       nil ->
         { :ok, req } = R.multipart_skip(req)
@@ -76,7 +76,7 @@ defmodule Dynamo.Cowboy.BodyParser do
             case List.keyfind(parts, "filename", 0) do
               { _, filename } ->
                 { _, type } = List.keyfind(headers, "content-type", 0) || { "content-type", nil }
-                { name, Dynamo.Connection.File[name: name, filename: filename, content_type: type, path: nil] }
+                { name, %Dynamo.Connection.File{name: name, filename: filename, content_type: type, path: nil} }
               _ ->
                 { name, nil }
             end

--- a/lib/dynamo/cowboy/body_parser.ex
+++ b/lib/dynamo/cowboy/body_parser.ex
@@ -39,7 +39,7 @@ defmodule Dynamo.Cowboy.BodyParser do
         { path, { :ok, req } } = Dynamo.Connection.Utils.random_file("uploaded",
           tmp_dir, &parse_multipart_file(R.part_body(req), &1))
 
-        parse_multipart(R.part(req), tmp_dir, [{ name, file.path(path) }|acc])
+        parse_multipart(R.part(req), tmp_dir, [{ name, %Dynamo.Connection.File{file | path: path} }|acc])
 
       nil ->
         { :ok, req } = R.multipart_skip(req)

--- a/lib/dynamo/cowboy/body_parser.ex
+++ b/lib/dynamo/cowboy/body_parser.ex
@@ -33,7 +33,7 @@ defmodule Dynamo.Cowboy.BodyParser do
         { body, req } = parse_multipart_body(R.part_body(req), "")
         parse_multipart(R.part(req), tmp_dir, [{ name, body }|acc])
 
-      { name, Dynamo.Connection.File[] = file } ->
+      { name, %Dynamo.Connection.File{} = file } ->
         tmp_dir = get_tmp_dir(tmp_dir)
 
         { path, { :ok, req } } = Dynamo.Connection.Utils.random_file("uploaded",
@@ -76,7 +76,7 @@ defmodule Dynamo.Cowboy.BodyParser do
             case List.keyfind(parts, "filename", 0) do
               { _, filename } ->
                 { _, type } = List.keyfind(headers, "content-type", 0) || { "content-type", nil }
-                { name, Dynamo.Connection.File[name: name, filename: filename, content_type: type, path: nil] }
+                { name, %Dynamo.Connection.File{name: name, filename: filename, content_type: type, path: nil} }
               _ ->
                 { name, nil }
             end

--- a/lib/dynamo/cowboy/connection.ex
+++ b/lib/dynamo/cowboy/connection.ex
@@ -152,7 +152,7 @@ defmodule Dynamo.Cowboy.Connection do
 
   @doc false
   def sendfile(status, path, conn) do
-    File.Stat[type: :regular, size: size] = File.stat!(path)
+    %File.Stat{type: :regular, size: size} = File.stat!(path)
     body_fun = fn (socket, transport) ->
                     case transport.sendfile(socket, path) do
                       {:ok, _sent} ->

--- a/lib/dynamo/cowboy/connection.ex
+++ b/lib/dynamo/cowboy/connection.ex
@@ -9,7 +9,7 @@ defmodule Dynamo.Cowboy.Connection do
   internally by Dynamo but may also be used by other
   developers (with caution).
   """
-  def cowboy_request(connection(req: req)) do
+  def cowboy_request(%Connection{req: req}) do
     req
   end
 
@@ -17,7 +17,7 @@ defmodule Dynamo.Cowboy.Connection do
   Sets the underlying cowboy request.
   """
   def cowboy_request(req, conn) do
-    connection(conn, req: req)
+    %Connection{conn | req: req}
   end
 
   @doc false
@@ -27,74 +27,74 @@ defmodule Dynamo.Cowboy.Connection do
 
     segments = split_path(path)
 
-    connection(
+    %Connection{
       main: main,
       before_send: Dynamo.Connection.default_before_send,
       method: verb,
       path_info_segments: segments,
       req: req,
       scheme: scheme
-    )
+    }
   end
 
   ## Request API
 
   @doc false
-  def peer(connection(req: req)) do
+  def peer(%Connection{req: req}) do
     {{peer,_}, _}  = R.peer req
     peer
   end
 
   @doc false
-  def original_method(connection(req: req)) do
+  def original_method(%Connection{req: req}) do
     { method, _ } = R.method req
     method
   end
 
   @doc false
-  def query_string(connection(req: req)) do
+  def query_string(%Connection{req: req}) do
     { query_string, _ } = R.qs req
     query_string
   end
 
   @doc false
-  def path_segments(connection(req: req)) do
+  def path_segments(%Connection{req: req}) do
     { path, _ } = R.path req
     split_path path
   end
 
   @doc false
-  def path(connection(req: req)) do
+  def path(%Connection{req: req}) do
     { binary, _ } = R.path req
     binary
   end
 
   @doc false
-  def version(connection(req: req)) do
+  def version(%Connection{req: req}) do
     { version, _ } = R.version req
     version
   end
 
   @doc false
-  def host(connection(req: req)) do
+  def host(%Connection{req: req}) do
     { host, _ } = R.host req
     host
   end
 
   @doc false
-  def port(connection(req: req)) do
+  def port(%Connection{req: req}) do
     { port, _ } = R.port req
     port
   end
 
   @doc false
-  def host_url(connection(req: req)) do
+  def host_url(%Connection{req: req}) do
     { host_url, _ } = R.host_url req
     host_url
   end
 
   @doc false
-  def scheme(connection(scheme: scheme)) do
+  def scheme(%Connection{scheme: scheme}) do
     scheme
   end
 
@@ -112,38 +112,39 @@ defmodule Dynamo.Cowboy.Connection do
   end
 
   @doc false
-  def send(status, body, connection(state: state) = conn) when state in [:unset, :set] and is_binary(body) do
-    conn = run_before_send(connection(conn, status: status, resp_body: body, state: :set))
-    connection(req: req, status: status, resp_body: body,
-               resp_headers: headers, resp_cookies: cookies) = conn
+  def send(status, body, %Connection{state: state} = conn) when state in [:unset, :set] and is_binary(body) do
+    conn = run_before_send(%Connection{conn | status: status, resp_body: body, state: :set})
+    %Connection{req: req, status: status, resp_body: body,
+               resp_headers: headers, resp_cookies: cookies} = conn
 
     merged_resp_headers = Dynamo.Connection.Utils.merge_resp_headers(headers, cookies)
     { :ok, req } = R.reply(status, merged_resp_headers, body, req)
 
-    connection(conn,
+    %Connection{conn |
       req: req,
       resp_body: nil,
       state: :sent
-    )
+    }
   end
 
   @doc false
-  def send_chunked(status, connection(state: state) = conn)
+  def send_chunked(status, %Connection{state: state} = conn)
       when is_integer(status) and state in [:unset, :set] do
-    conn = run_before_send(connection(conn, status: status, state: :chunked))
-    connection(status: status, req: req,
-               resp_headers: headers, resp_cookies: cookies) = conn
+    conn = run_before_send(%Connection{conn | status: status, state: :chunked})
+    %Connection{status: status, req: req,
+               resp_headers: headers, resp_cookies: cookies} = conn
     merged_resp_headers = Dynamo.Connection.Utils.merge_resp_headers(headers, cookies)
 
     { :ok, req } = R.chunked_reply(status, merged_resp_headers, req)
 
-    connection(conn,
+    %Connection{conn |
       req: req,
-      resp_body: nil)
+      resp_body: nil
+    }
   end
 
   @doc false
-  def chunk(body, connection(state: state, req: req) = conn) when state == :chunked do
+  def chunk(body, %Connection{state: state, req: req} = conn) when state == :chunked do
     case R.chunk(body, req) do
       :ok   -> { :ok, conn }
       other -> other
@@ -152,7 +153,7 @@ defmodule Dynamo.Cowboy.Connection do
 
   @doc false
   def sendfile(status, path, conn) do
-    File.Stat[type: :regular, size: size] = File.stat!(path)
+    %File.Stat{type: :regular, size: size} = File.stat!(path)
     body_fun = fn (socket, transport) ->
                     case transport.sendfile(socket, path) do
                       {:ok, _sent} ->
@@ -164,56 +165,56 @@ defmodule Dynamo.Cowboy.Connection do
                     end
                end
 
-    conn = run_before_send(connection(conn, status: status, state: :sendfile))
-    connection(req: req, status: status,
-               resp_headers: headers, resp_cookies: cookies) = conn
+    conn = run_before_send(%Connection{conn | status: status, state: :sendfile})
+    %Connection{req: req, status: status,
+               resp_headers: headers, resp_cookies: cookies} = conn
 
     merged_resp_headers = Dynamo.Connection.Utils.merge_resp_headers(headers, cookies)
     req = R.set_resp_body_fun(size, body_fun, req)
     { :ok, req } = R.reply(status, merged_resp_headers, req)
 
-    connection(conn,
+    %Connection{conn |
       req: req,
       resp_body: nil,
       state: :sent
-    )
+    }
   end
 
   ## Misc
 
   @doc false
-  def fetch(list, conn) when is_list(list) do
+  def fetch(list, %Connection{} = conn) when is_list(list) do
     Enum.reduce list, conn, fn(item, acc) -> acc.fetch(item) end
   end
 
-  def fetch(:body, connection(req: req, req_body: nil) = conn) do
+  def fetch(:body, %Connection{req: req, req_body: nil} = conn) do
     { :ok, body, req } = R.body req
-    connection(conn, req: req, req_body: body)
+    %Connection{conn | req: req, req_body: body}
   end
 
-  def fetch(:params, connection(req: req, params: nil, route_params: route_params) = conn) do
+  def fetch(:params, %Connection{req: req, params: nil, route_params: route_params} = conn) do
     { query_string, req } = R.qs req
     params = Dynamo.Connection.QueryParser.parse(query_string)
     { params, req } = Dynamo.Cowboy.BodyParser.parse(params, req)
-    connection(conn, req: req, params: merge_route_params(params, route_params))
+    %Connection{conn | req: req, params: merge_route_params(params, route_params)}
   end
 
-  def fetch(:cookies, connection(req: req, req_cookies: nil) = conn) do
+  def fetch(:cookies, %Connection{req: req, req_cookies: nil} = conn) do
     { cookies, req } = R.cookies req
-    connection(conn, req: req, req_cookies: Binary.Dict.new(cookies))
+    %Connection{conn | req: req, req_cookies: Binary.Dict.new(cookies)}
   end
 
-  def fetch(:headers, connection(req: req, req_headers: nil) = conn) do
+  def fetch(:headers, %Connection{req: req, req_headers: nil} = conn) do
     { headers, req } = R.headers req
-    connection(conn, req: req, req_headers: Binary.Dict.new(headers))
+    %Connection{conn | req: req, req_headers: Binary.Dict.new(headers)}
   end
 
   # The given aspect was already loaded.
-  def fetch(aspect, conn) when aspect in [:params, :cookies, :headers, :body] do
+  def fetch(aspect, %Connection{} = conn) when aspect in [:params, :cookies, :headers, :body] do
     conn
   end
 
-  def fetch(aspect, connection(fetchable: fetchable) = conn) when is_atom(aspect) do
+  def fetch(aspect, %Connection{fetchable: fetchable} = conn) when is_atom(aspect) do
     case Keyword.get(fetchable, aspect) do
       nil -> raise Dynamo.Connection.UnknownFetchError, aspect: aspect
       fun -> fun.(conn)

--- a/lib/dynamo/cowboy/connection.ex
+++ b/lib/dynamo/cowboy/connection.ex
@@ -152,7 +152,7 @@ defmodule Dynamo.Cowboy.Connection do
 
   @doc false
   def sendfile(status, path, conn) do
-    %File.Stat{type: :regular, size: size} = File.stat!(path)
+    File.Stat[type: :regular, size: size] = File.stat!(path)
     body_fun = fn (socket, transport) ->
                     case transport.sendfile(socket, path) do
                       {:ok, _sent} ->

--- a/lib/dynamo/cowboy/connection.ex
+++ b/lib/dynamo/cowboy/connection.ex
@@ -9,7 +9,7 @@ defmodule Dynamo.Cowboy.Connection do
   internally by Dynamo but may also be used by other
   developers (with caution).
   """
-  def cowboy_request(%Connection{req: req}) do
+  def cowboy_request(connection(req: req)) do
     req
   end
 
@@ -17,7 +17,7 @@ defmodule Dynamo.Cowboy.Connection do
   Sets the underlying cowboy request.
   """
   def cowboy_request(req, conn) do
-    %Connection{conn | req: req}
+    connection(conn, req: req)
   end
 
   @doc false
@@ -27,74 +27,74 @@ defmodule Dynamo.Cowboy.Connection do
 
     segments = split_path(path)
 
-    %Connection{
+    connection(
       main: main,
       before_send: Dynamo.Connection.default_before_send,
       method: verb,
       path_info_segments: segments,
       req: req,
       scheme: scheme
-    }
+    )
   end
 
   ## Request API
 
   @doc false
-  def peer(%Connection{req: req}) do
+  def peer(connection(req: req)) do
     {{peer,_}, _}  = R.peer req
     peer
   end
 
   @doc false
-  def original_method(%Connection{req: req}) do
+  def original_method(connection(req: req)) do
     { method, _ } = R.method req
     method
   end
 
   @doc false
-  def query_string(%Connection{req: req}) do
+  def query_string(connection(req: req)) do
     { query_string, _ } = R.qs req
     query_string
   end
 
   @doc false
-  def path_segments(%Connection{req: req}) do
+  def path_segments(connection(req: req)) do
     { path, _ } = R.path req
     split_path path
   end
 
   @doc false
-  def path(%Connection{req: req}) do
+  def path(connection(req: req)) do
     { binary, _ } = R.path req
     binary
   end
 
   @doc false
-  def version(%Connection{req: req}) do
+  def version(connection(req: req)) do
     { version, _ } = R.version req
     version
   end
 
   @doc false
-  def host(%Connection{req: req}) do
+  def host(connection(req: req)) do
     { host, _ } = R.host req
     host
   end
 
   @doc false
-  def port(%Connection{req: req}) do
+  def port(connection(req: req)) do
     { port, _ } = R.port req
     port
   end
 
   @doc false
-  def host_url(%Connection{req: req}) do
+  def host_url(connection(req: req)) do
     { host_url, _ } = R.host_url req
     host_url
   end
 
   @doc false
-  def scheme(%Connection{scheme: scheme}) do
+  def scheme(connection(scheme: scheme)) do
     scheme
   end
 
@@ -112,39 +112,38 @@ defmodule Dynamo.Cowboy.Connection do
   end
 
   @doc false
-  def send(status, body, %Connection{state: state} = conn) when state in [:unset, :set] and is_binary(body) do
-    conn = run_before_send(%Connection{conn | status: status, resp_body: body, state: :set})
-    %Connection{req: req, status: status, resp_body: body,
-               resp_headers: headers, resp_cookies: cookies} = conn
+  def send(status, body, connection(state: state) = conn) when state in [:unset, :set] and is_binary(body) do
+    conn = run_before_send(connection(conn, status: status, resp_body: body, state: :set))
+    connection(req: req, status: status, resp_body: body,
+               resp_headers: headers, resp_cookies: cookies) = conn
 
     merged_resp_headers = Dynamo.Connection.Utils.merge_resp_headers(headers, cookies)
     { :ok, req } = R.reply(status, merged_resp_headers, body, req)
 
-    %Connection{conn |
+    connection(conn,
       req: req,
       resp_body: nil,
       state: :sent
-    }
+    )
   end
 
   @doc false
-  def send_chunked(status, %Connection{state: state} = conn)
+  def send_chunked(status, connection(state: state) = conn)
       when is_integer(status) and state in [:unset, :set] do
-    conn = run_before_send(%Connection{conn | status: status, state: :chunked})
-    %Connection{status: status, req: req,
-               resp_headers: headers, resp_cookies: cookies} = conn
+    conn = run_before_send(connection(conn, status: status, state: :chunked))
+    connection(status: status, req: req,
+               resp_headers: headers, resp_cookies: cookies) = conn
     merged_resp_headers = Dynamo.Connection.Utils.merge_resp_headers(headers, cookies)
 
     { :ok, req } = R.chunked_reply(status, merged_resp_headers, req)
 
-    %Connection{conn |
+    connection(conn,
       req: req,
-      resp_body: nil
-    }
+      resp_body: nil)
   end
 
   @doc false
-  def chunk(body, %Connection{state: state, req: req} = conn) when state == :chunked do
+  def chunk(body, connection(state: state, req: req) = conn) when state == :chunked do
     case R.chunk(body, req) do
       :ok   -> { :ok, conn }
       other -> other
@@ -153,7 +152,7 @@ defmodule Dynamo.Cowboy.Connection do
 
   @doc false
   def sendfile(status, path, conn) do
-    %File.Stat{type: :regular, size: size} = File.stat!(path)
+    File.Stat[type: :regular, size: size] = File.stat!(path)
     body_fun = fn (socket, transport) ->
                     case transport.sendfile(socket, path) do
                       {:ok, _sent} ->
@@ -165,56 +164,56 @@ defmodule Dynamo.Cowboy.Connection do
                     end
                end
 
-    conn = run_before_send(%Connection{conn | status: status, state: :sendfile})
-    %Connection{req: req, status: status,
-               resp_headers: headers, resp_cookies: cookies} = conn
+    conn = run_before_send(connection(conn, status: status, state: :sendfile))
+    connection(req: req, status: status,
+               resp_headers: headers, resp_cookies: cookies) = conn
 
     merged_resp_headers = Dynamo.Connection.Utils.merge_resp_headers(headers, cookies)
     req = R.set_resp_body_fun(size, body_fun, req)
     { :ok, req } = R.reply(status, merged_resp_headers, req)
 
-    %Connection{conn |
+    connection(conn,
       req: req,
       resp_body: nil,
       state: :sent
-    }
+    )
   end
 
   ## Misc
 
   @doc false
-  def fetch(list, %Connection{} = conn) when is_list(list) do
+  def fetch(list, conn) when is_list(list) do
     Enum.reduce list, conn, fn(item, acc) -> acc.fetch(item) end
   end
 
-  def fetch(:body, %Connection{req: req, req_body: nil} = conn) do
+  def fetch(:body, connection(req: req, req_body: nil) = conn) do
     { :ok, body, req } = R.body req
-    %Connection{conn | req: req, req_body: body}
+    connection(conn, req: req, req_body: body)
   end
 
-  def fetch(:params, %Connection{req: req, params: nil, route_params: route_params} = conn) do
+  def fetch(:params, connection(req: req, params: nil, route_params: route_params) = conn) do
     { query_string, req } = R.qs req
     params = Dynamo.Connection.QueryParser.parse(query_string)
     { params, req } = Dynamo.Cowboy.BodyParser.parse(params, req)
-    %Connection{conn | req: req, params: merge_route_params(params, route_params)}
+    connection(conn, req: req, params: merge_route_params(params, route_params))
   end
 
-  def fetch(:cookies, %Connection{req: req, req_cookies: nil} = conn) do
+  def fetch(:cookies, connection(req: req, req_cookies: nil) = conn) do
     { cookies, req } = R.cookies req
-    %Connection{conn | req: req, req_cookies: Binary.Dict.new(cookies)}
+    connection(conn, req: req, req_cookies: Binary.Dict.new(cookies))
   end
 
-  def fetch(:headers, %Connection{req: req, req_headers: nil} = conn) do
+  def fetch(:headers, connection(req: req, req_headers: nil) = conn) do
     { headers, req } = R.headers req
-    %Connection{conn | req: req, req_headers: Binary.Dict.new(headers)}
+    connection(conn, req: req, req_headers: Binary.Dict.new(headers))
   end
 
   # The given aspect was already loaded.
-  def fetch(aspect, %Connection{} = conn) when aspect in [:params, :cookies, :headers, :body] do
+  def fetch(aspect, conn) when aspect in [:params, :cookies, :headers, :body] do
     conn
   end
 
-  def fetch(aspect, %Connection{fetchable: fetchable} = conn) when is_atom(aspect) do
+  def fetch(aspect, connection(fetchable: fetchable) = conn) when is_atom(aspect) do
     case Keyword.get(fetchable, aspect) do
       nil -> raise Dynamo.Connection.UnknownFetchError, aspect: aspect
       fun -> fun.(conn)

--- a/lib/dynamo/filters/exceptions.ex
+++ b/lib/dynamo/filters/exceptions.ex
@@ -39,7 +39,7 @@ defmodule Dynamo.Filters.Exceptions do
     end
 
     message = logger_conn(conn) <> logger_reason(kind, value) <> logger_stacktrace(stacktrace)
-    message = String.to_char_list!(message)
+    message = List.from_char_data!(message)
     :error_logger.error_msg(message)
 
     if conn.already_sent? do

--- a/lib/dynamo/filters/exceptions/debug.ex
+++ b/lib/dynamo/filters/exceptions/debug.ex
@@ -22,7 +22,9 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 defmodule Dynamo.Filters.Exceptions.Debug do
-  defrecord Frame, [:module, :function, :file, :line, :context, :index, :snippet, :link]
+  defmodule Frame do
+    defstruct [:module, :function, :file, :line, :context, :index, :snippet, :link]
+  end
 
   import Dynamo.Helpers.Escaping
 
@@ -62,7 +64,7 @@ defmodule Dynamo.Filters.Exceptions.Debug do
     { file, line } = { to_string(opts[:file] || "nofile"), opts[:line] }
     { relative, context, snippet } = file_context(file, line, root, sources)
 
-    { Frame[
+    { %Frame{
         module: mod,
         function: fun,
         file: relative,
@@ -71,7 +73,7 @@ defmodule Dynamo.Filters.Exceptions.Debug do
         snippet: snippet,
         index: index,
         link: editor_link(file, line, editor)
-      ], index + 1 }
+      }, index + 1 }
   end
 
   def mod_fun(module, :__MODULE__, 0) do

--- a/lib/dynamo/filters/methodoverride.ex
+++ b/lib/dynamo/filters/methodoverride.ex
@@ -17,6 +17,6 @@ defmodule Dynamo.Filters.MethodOverride do
 
   defp method_override(conn) do
     conn = conn.fetch([:params, :headers])
-    Dict.get(conn.params, :_method) || Dict.get(conn.req_headers, "x-http-method-override")
+    Binary.Dict.get(conn.params, :_method) || Binary.Dict.get(conn.req_headers, "x-http-method-override")
   end
 end

--- a/lib/dynamo/loader.ex
+++ b/lib/dynamo/loader.ex
@@ -120,8 +120,8 @@ defmodule Dynamo.Loader do
   end
 
   @doc false
-  def handle_call(:paths, _from, %Config{} = config) do
-    { :reply, config.paths, config }
+  def handle_call(:paths, _from, %Config{paths: paths} = config) do
+    { :reply, paths, config }
   end
 
   def handle_call(:conditional_purge, _from, %Config{paths: paths, updated_at: updated_at} = config) do
@@ -133,7 +133,7 @@ defmodule Dynamo.Loader do
       purge_all(config)
       unload_all(config)
       { :reply, { :purged, Enum.reverse(config.on_purge) },
-        config.loaded_modules([]).loaded_files([]).updated_at(last_modified) }
+        %Config{config | loaded_modules: [], loaded_files: [], updated_at: last_modified} }
     end
   end
 
@@ -146,17 +146,17 @@ defmodule Dynamo.Loader do
   end
 
   @doc false
-  def handle_cast({ :loaded, file, modules }, %Config{} = config) do
-    { :noreply, config.update_loaded_modules(&(modules ++ &1)).update_loaded_files(&([file|&1])) }
+  def handle_cast({ :loaded, file, modules }, %Config{loaded_modules: loaded_modules, loaded_files: loaded_files} = config) do
+    { :noreply, %Config{config | loaded_modules: modules ++ loaded_modules, loaded_files: [file|loaded_files]} }
   end
 
-  def handle_cast({ :on_purge, fun }, %Config{} = config) do
-    { :noreply, config.update_on_purge(&([fun|&1])) }
+  def handle_cast({ :on_purge, fun }, %Config{on_purge: on_purge} = config) do
+    { :noreply, %Config{config | on_purge: [fun|on_purge] } }
   end
 
   def handle_cast({ :append_paths, paths }, %Config{} = config) do
     updated_at = last_modified(paths, config.updated_at)
-    { :noreply, config.update_paths(&(&1 ++ paths)).updated_at(updated_at) }
+    { :noreply, %Config{config | paths: config.paths ++ paths, updated_at: updated_at} }
   end
 
   def handle_cast(arg, config) do

--- a/lib/dynamo/loader.ex
+++ b/lib/dynamo/loader.ex
@@ -100,8 +100,9 @@ defmodule Dynamo.Loader do
 
   ## Backend
 
-  defrecord Config, loaded_modules: [], loaded_files: [], paths: nil,
-    updated_at: { { 1970, 1, 1 }, { 0, 0, 0 } }, on_purge: []
+  defmodule Config do
+    defstruct [loaded_modules: [], loaded_files: [], paths: nil, updated_at: { { 1970, 1, 1 }, { 0, 0, 0 } }, on_purge: []]
+  end
 
   @doc false
   def start_link do
@@ -115,15 +116,15 @@ defmodule Dynamo.Loader do
 
   @doc false
   def init(paths) do
-    { :ok, Config[paths: paths] }
+    { :ok, %Config{paths: paths} }
   end
 
   @doc false
-  def handle_call(:paths, _from, Config[] = config) do
+  def handle_call(:paths, _from, %Config{} = config) do
     { :reply, config.paths, config }
   end
 
-  def handle_call(:conditional_purge, _from, Config[paths: paths, updated_at: updated_at] = config) do
+  def handle_call(:conditional_purge, _from, %Config{paths: paths, updated_at: updated_at} = config) do
     last_modified = last_modified(paths, updated_at)
 
     if last_modified == updated_at do
@@ -145,15 +146,15 @@ defmodule Dynamo.Loader do
   end
 
   @doc false
-  def handle_cast({ :loaded, file, modules }, Config[] = config) do
+  def handle_cast({ :loaded, file, modules }, %Config{} = config) do
     { :noreply, config.update_loaded_modules(&(modules ++ &1)).update_loaded_files(&([file|&1])) }
   end
 
-  def handle_cast({ :on_purge, fun }, Config[] = config) do
+  def handle_cast({ :on_purge, fun }, %Config{} = config) do
     { :noreply, config.update_on_purge(&([fun|&1])) }
   end
 
-  def handle_cast({ :append_paths, paths }, Config[] = config) do
+  def handle_cast({ :append_paths, paths }, %Config{} = config) do
     updated_at = last_modified(paths, config.updated_at)
     { :noreply, config.update_paths(&(&1 ++ paths)).updated_at(updated_at) }
   end
@@ -183,7 +184,7 @@ defmodule Dynamo.Loader do
 
   defp max_last_modified(path, latest) do
     case File.stat(path) do
-      { :ok, File.Stat[mtime: mtime] } -> max(latest, mtime)
+      { :ok, %File.Stat{mtime: mtime} } -> max(latest, mtime)
       { :error, _ } -> latest
     end
   end

--- a/lib/dynamo/loader.ex
+++ b/lib/dynamo/loader.ex
@@ -184,7 +184,7 @@ defmodule Dynamo.Loader do
 
   defp max_last_modified(path, latest) do
     case File.stat(path) do
-      { :ok, %File.Stat{mtime: mtime} } -> max(latest, mtime)
+      { :ok, File.Stat[mtime: mtime] } -> max(latest, mtime)
       { :error, _ } -> latest
     end
   end

--- a/lib/dynamo/router/utils.ex
+++ b/lib/dynamo/router/utils.ex
@@ -140,11 +140,11 @@ defmodule Dynamo.Router.Utils do
   end
 
   defp list_split(bin) do
-    lc segment inlist String.split(bin, "/"), segment != "", do: String.to_char_list!(segment)
+    lc segment inlist String.split(bin, "/"), segment != "", do: List.from_char_data!(segment)
   end
 
   defp binary_from_buffer(buffer) do
-    iolist_to_binary(Enum.reverse(buffer))
+    iodata_to_binary(Enum.reverse(buffer))
   end
 
   def is_function_exported?(module, function, arity) do

--- a/lib/dynamo/static.ex
+++ b/lib/dynamo/static.ex
@@ -35,7 +35,9 @@ defmodule Dynamo.Static do
     :gen_server.call(server, :stop)
   end
 
-  defrecord Config, [:ets, :route, :root, :cache]
+  defmodule Config do
+    defstruct [:ets, :route, :root, :cache]
+  end
 
   @doc false
   def init(dynamo) do
@@ -46,11 +48,11 @@ defmodule Dynamo.Static do
 
     { ets, _server } = dynamo.static_cache
     :ets.new(ets, [:set, :protected, :named_table, { :read_concurrency, true }])
-    { :ok, Config[ets: ets, route: route, root: root, cache: cache] }
+    { :ok, %Config{ets: ets, route: route, root: root, cache: cache} }
   end
 
   @doc false
-  def handle_call({ :lookup, path }, _from, Config[] = config) do
+  def handle_call({ :lookup, path }, _from, %Config{} = config) do
     result = static_path(path, config)
     if config.cache, do: :ets.insert(config.ets, { path, result })
     { :reply, result, config }
@@ -66,7 +68,7 @@ defmodule Dynamo.Static do
 
   ## Server helpers
 
-  defp static_path(path, Config[] = config) do
+  defp static_path(path, %Config{} = config) do
     case File.stat(Path.join(config.root, path)) do
       { :ok, File.Stat[mtime: mtime, type: type] } when type != :directory and is_tuple(mtime) ->
         seconds = :calendar.datetime_to_gregorian_seconds(mtime)

--- a/lib/dynamo/static.ex
+++ b/lib/dynamo/static.ex
@@ -70,7 +70,7 @@ defmodule Dynamo.Static do
 
   defp static_path(path, %Config{} = config) do
     case File.stat(Path.join(config.root, path)) do
-      { :ok, %File.Stat{mtime: mtime, type: type} } when type != :directory and is_tuple(mtime) ->
+      { :ok, File.Stat[mtime: mtime, type: type] } when type != :directory and is_tuple(mtime) ->
         seconds = :calendar.datetime_to_gregorian_seconds(mtime)
         Path.join(config.route, [path, ??, integer_to_list(seconds)])
       _ ->

--- a/lib/dynamo/static.ex
+++ b/lib/dynamo/static.ex
@@ -35,7 +35,9 @@ defmodule Dynamo.Static do
     :gen_server.call(server, :stop)
   end
 
-  defrecord Config, [:ets, :route, :root, :cache]
+  defmodule Config do
+    defstruct [:ets, :route, :root, :cache]
+  end
 
   @doc false
   def init(dynamo) do
@@ -46,11 +48,11 @@ defmodule Dynamo.Static do
 
     { ets, _server } = dynamo.static_cache
     :ets.new(ets, [:set, :protected, :named_table, { :read_concurrency, true }])
-    { :ok, Config[ets: ets, route: route, root: root, cache: cache] }
+    { :ok, %Config{ets: ets, route: route, root: root, cache: cache} }
   end
 
   @doc false
-  def handle_call({ :lookup, path }, _from, Config[] = config) do
+  def handle_call({ :lookup, path }, _from, %Config{} = config) do
     result = static_path(path, config)
     if config.cache, do: :ets.insert(config.ets, { path, result })
     { :reply, result, config }
@@ -66,9 +68,9 @@ defmodule Dynamo.Static do
 
   ## Server helpers
 
-  defp static_path(path, Config[] = config) do
+  defp static_path(path, %Config{} = config) do
     case File.stat(Path.join(config.root, path)) do
-      { :ok, File.Stat[mtime: mtime, type: type] } when type != :directory and is_tuple(mtime) ->
+      { :ok, %File.Stat{mtime: mtime, type: type} } when type != :directory and is_tuple(mtime) ->
         seconds = :calendar.datetime_to_gregorian_seconds(mtime)
         Path.join(config.route, [path, ??, integer_to_list(seconds)])
       _ ->

--- a/lib/dynamo/templates.ex
+++ b/lib/dynamo/templates.ex
@@ -1,7 +1,6 @@
-defrecord Dynamo.Template, key: nil, identifier: nil, format: nil,
-    handler: nil, updated_at: nil, extra: nil, ref: nil, finder: nil do
+defmodule Dynamo.Template do
   @moduledoc """
-  The template record is responsible to keep information about
+  The template struct is responsible for keeping information about
   templates to be rendered. It contains:
 
   * `:key` - The key used to find the template;
@@ -18,6 +17,8 @@ defrecord Dynamo.Template, key: nil, identifier: nil, format: nil,
 
   * `:ref` - A reference for already compiled templates
   """
+  defstruct [key: nil, identifier: nil, format: nil,
+  handler: nil, updated_at: nil, extra: nil, ref: nil, finder: nil]
 end
 
 defexception Dynamo.TemplateNotFound, query: nil, paths: nil do
@@ -78,8 +79,8 @@ defmodule Dynamo.Templates do
   """
   def compile_module(name, templates, locals, prelude) do
     { finders, _ } =
-      Enum.map_reduce templates, 0, fn(Dynamo.Template[] = template, i) ->
-        template = template.ref({ name, :"dynamo_template_#{i}" })
+      Enum.map_reduce templates, 0, fn(%Dynamo.Template{} = template, i) ->
+        template = %Dynamo.Template{template | ref: { name, :"dynamo_template_#{i}" }}
         finder   = quote do
           def find(unquote(template.key)) do
             unquote(Macro.escape(template))
@@ -89,7 +90,7 @@ defmodule Dynamo.Templates do
       end
 
     { templates, _ } =
-      Enum.map_reduce templates, 0, fn(Dynamo.Template[] = template, i) ->
+      Enum.map_reduce templates, 0, fn(%Dynamo.Template{} = template, i) ->
         source = Dynamo.Templates.Finder.source(template.finder, template)
         { args, source } = template.handler.compile(template, source, locals)
 

--- a/lib/dynamo/templates.ex
+++ b/lib/dynamo/templates.ex
@@ -80,7 +80,7 @@ defmodule Dynamo.Templates do
   def compile_module(name, templates, locals, prelude) do
     { finders, _ } =
       Enum.map_reduce templates, 0, fn(%Dynamo.Template{} = template, i) ->
-        template = template.ref({ name, :"dynamo_template_#{i}" })
+        template = %Dynamo.Template{template | ref: { name, :"dynamo_template_#{i}" }}
         finder   = quote do
           def find(unquote(template.key)) do
             unquote(Macro.escape(template))

--- a/lib/dynamo/templates.ex
+++ b/lib/dynamo/templates.ex
@@ -1,7 +1,6 @@
-defrecord Dynamo.Template, key: nil, identifier: nil, format: nil,
-    handler: nil, updated_at: nil, extra: nil, ref: nil, finder: nil do
+defmodule Dynamo.Template do
   @moduledoc """
-  The template record is responsible to keep information about
+  The template struct is responsible for keeping information about
   templates to be rendered. It contains:
 
   * `:key` - The key used to find the template;
@@ -18,6 +17,8 @@ defrecord Dynamo.Template, key: nil, identifier: nil, format: nil,
 
   * `:ref` - A reference for already compiled templates
   """
+  defstruct [key: nil, identifier: nil, format: nil,
+  handler: nil, updated_at: nil, extra: nil, ref: nil, finder: nil]
 end
 
 defexception Dynamo.TemplateNotFound, query: nil, paths: nil do
@@ -78,7 +79,7 @@ defmodule Dynamo.Templates do
   """
   def compile_module(name, templates, locals, prelude) do
     { finders, _ } =
-      Enum.map_reduce templates, 0, fn(Dynamo.Template[] = template, i) ->
+      Enum.map_reduce templates, 0, fn(%Dynamo.Template{} = template, i) ->
         template = template.ref({ name, :"dynamo_template_#{i}" })
         finder   = quote do
           def find(unquote(template.key)) do
@@ -89,7 +90,7 @@ defmodule Dynamo.Templates do
       end
 
     { templates, _ } =
-      Enum.map_reduce templates, 0, fn(Dynamo.Template[] = template, i) ->
+      Enum.map_reduce templates, 0, fn(%Dynamo.Template{} = template, i) ->
         source = Dynamo.Templates.Finder.source(template.finder, template)
         { args, source } = template.handler.compile(template, source, locals)
 

--- a/lib/dynamo/templates/finder.ex
+++ b/lib/dynamo/templates/finder.ex
@@ -53,7 +53,7 @@ defimpl Dynamo.Templates.Finder, for: BitString do
     if path, do: build(root, key, path)
   end
 
-  def source(_root, Dynamo.Template[identifier: path]) do
+  def source(_root, %Dynamo.Template{identifier: path}) do
     File.read!(path)
   end
 
@@ -68,14 +68,14 @@ defimpl Dynamo.Templates.Finder, for: BitString do
   end
 
   defp build(root, key, path) do
-    Dynamo.Template[
+    %Dynamo.Template{
       key: key,
       updated_at: File.stat!(path).mtime,
       identifier: path,
       handler: Dynamo.Templates.Handler.get!(extname(path)),
       format: extname(Path.rootname(path)),
       finder: root
-    ]
+    }
   end
 
   defp extname(path) do

--- a/lib/dynamo/templates/handler.ex
+++ b/lib/dynamo/templates/handler.ex
@@ -50,7 +50,7 @@ defmodule Dynamo.Templates.EEXHandler do
   @moduledoc false
   @behaviour Dynamo.Templates.Handler
 
-  def compile(Dynamo.Template[identifier: identifier], source, locals) do
+  def compile(%Dynamo.Template{identifier: identifier}, source, locals) do
     vars   = vars(locals)
     args   = [{ :assigns, [], nil }|vars]
     match  = match(args)

--- a/lib/dynamo/templates/renderer.ex
+++ b/lib/dynamo/templates/renderer.ex
@@ -35,11 +35,11 @@ defmodule Dynamo.Templates.Renderer do
   The on demand mode needs to be explicitly enabled
   by calling `start_link/0`.
   """
-  def render(_name, Template[ref: { mod, fun }, handler: handler], locals, assigns, _prelude) do
+  def render(_name, %Template{ref: { mod, fun }, handler: handler}, locals, assigns, _prelude) do
     handler.render(mod, fun, locals, assigns)
   end
 
-  def render(name, Template[handler: handler] = template, locals, assigns, prelude) do
+  def render(name, %Template{handler: handler} = template, locals, assigns, prelude) do
     module =
       case get_module(name, template) do
         { :ok, mod } ->
@@ -55,16 +55,16 @@ defmodule Dynamo.Templates.Renderer do
 
   ## Helpers
 
-  defp get_module(name, Template[identifier: identifier, updated_at: updated_at]) do
+  defp get_module(name, %Template{identifier: identifier, updated_at: updated_at}) do
     :gen_server.call(name, { :get_module, identifier, updated_at })
   end
 
-  defp put_module(name, module, Template[identifier: identifier, updated_at: updated_at]) do
+  defp put_module(name, module, %Template{identifier: identifier, updated_at: updated_at}) do
     :gen_server.cast(name, { :put_module, module, identifier, updated_at })
   end
 
   defp compile(name, module, template, locals, prelude) do
-    Template[handler: handler, identifier: identifier, finder: finder] = template
+    %Template{handler: handler, identifier: identifier, finder: finder} = template
     source = Dynamo.Templates.Finder.source(finder, template)
     { args, source } = handler.compile(template, source, locals)
 
@@ -81,7 +81,7 @@ defmodule Dynamo.Templates.Renderer do
     module
   end
 
-  defp raise_too_busy(Template[identifier: identifier]) do
+  defp raise_too_busy(%Template{identifier: identifier}) do
     raise "Compiling template #{inspect identifier} exceeded the max number of attempts #{@max_attempts}. What gives?"
   end
 

--- a/lib/dynamo/templates/renderer.ex
+++ b/lib/dynamo/templates/renderer.ex
@@ -94,10 +94,10 @@ defmodule Dynamo.Templates.Renderer do
 
   @doc false
   def handle_call({ :get_module, identifier, updated_at }, _from, { name, dict }) do
-    case Dict.get(dict, identifier) do
+    case Binary.Dict.get(dict, identifier) do
       { module, cached } when updated_at > cached ->
         spawn fn -> purge_module(module) end
-        { :reply, generate_suggestion(name, 0), { name, Dict.delete(dict, identifier) } }
+        { :reply, generate_suggestion(name, 0), { name, Binary.Dict.delete(dict, identifier) } }
       { module, _ } ->
         { :reply, { :ok, module }, { name, dict } }
       nil ->
@@ -123,7 +123,7 @@ defmodule Dynamo.Templates.Renderer do
   end
 
   def handle_cast({ :put_module, module, identifier, updated_at }, { name, dict }) do
-    { :noreply, { name, Dict.put(dict, identifier, { module, updated_at }) } }
+    { :noreply, { name, Binary.Dict.put(dict, identifier, { module, updated_at }) } }
   end
 
   def handle_cast(arg, config) do

--- a/lib/dynamo/utils/message_verifier.ex
+++ b/lib/dynamo/utils/message_verifier.ex
@@ -34,7 +34,7 @@ defmodule Dynamo.Utils.MessageVerifier do
 
   defp digest(secret, data) do
     <<mac :: [integer, size(160)]>> = :crypto.hmac(:sha, secret, data)
-    :erlang.integer_to_list(mac, 16) |> iolist_to_binary
+    :erlang.integer_to_list(mac, 16) |> iodata_to_binary
   end
 
   @doc """

--- a/lib/mix/tasks/compile.dynamo.ex
+++ b/lib/mix/tasks/compile.dynamo.ex
@@ -108,7 +108,7 @@ defmodule Mix.Tasks.Compile.Dynamo do
        template inlist templates, do: template
   end
 
-  defp template_mtime(Dynamo.Template[key: key, updated_at: updated_at]) do
+  defp template_mtime(%Dynamo.Template{key: key, updated_at: updated_at}) do
     { key, updated_at }
   end
 

--- a/test/dynamo/filters/exceptions/debug_test.exs
+++ b/test/dynamo/filters/exceptions/debug_test.exs
@@ -54,7 +54,7 @@ defmodule Dynamo.Filters.Exceptions.DebugTest do
   end
 
   defp stacktrace do
-    [ { Dynamo.Filters.Exceptions.DebugTest, :stacktrace, 0, __ENV__.location },
+    [ { Dynamo.Filters.Exceptions.DebugTest, :stacktrace, 0, [file: __ENV__.file, lilne: __ENV__.line] },
       { Dynamo.Filters.Exceptions.DebugTest, :stacktrace, 0, [file: __ENV__.file, line: 1000] },
       { Dynamo.Filters.Exceptions.DebugTest, :__MODULE__, 0, [file: __ENV__.file, line: 16] },
       { Dynamo, :__MODULE__, 0, [file: "lib/dynamo.ex", line: 1] } ]

--- a/test/dynamo/templates/finder_test.exs
+++ b/test/dynamo/templates/finder_test.exs
@@ -6,9 +6,9 @@ defmodule Dynamo.Templates.FinderTest do
   test "finds available template" do
     path = Path.join(@fixture_path, "hello.html.eex")
 
-    assert Dynamo.Template[identifier: ^path, key: "hello.html",
+    assert %Dynamo.Template{identifier: ^path, key: "hello.html",
       handler: Dynamo.Templates.EEXHandler, format: "html",
-      finder: @fixture_path] = Dynamo.Templates.Finder.find @fixture_path, "hello.html"
+      finder: @fixture_path} = Dynamo.Templates.Finder.find @fixture_path, "hello.html"
   end
 
   test "returns all templates" do

--- a/test/dynamo/templates_test.exs
+++ b/test/dynamo/templates_test.exs
@@ -66,9 +66,9 @@ defmodule Dynamo.TemplatesTest do
     path     = Path.join(@fixture_path, "hello.html.eex")
     template = CompileTest.CompiledTemplates.find "hello.html"
 
-    assert Dynamo.Template[identifier: ^path, key: "hello.html",
+    assert %Dynamo.Template{identifier: ^path, key: "hello.html",
       handler: Dynamo.Templates.EEXHandler, format: "html",
-      ref: { CompileTest.CompiledTemplates, _ }, finder: @fixture_path] = template
+      ref: { CompileTest.CompiledTemplates, _ }, finder: @fixture_path} = template
 
     { mod, fun } = template.ref
     assert apply(mod, fun, [[], nil]) == { [nil], "HELLO!" }

--- a/test/dynamo_test.exs
+++ b/test/dynamo_test.exs
@@ -37,7 +37,7 @@ defmodule DynamoTest do
   ## Config
 
   test "defines root based on otp app" do
-    assert ReloadApp.root == String.from_char_list! :code.lib_dir(:dynamo)
+    assert ReloadApp.root == String.from_char_data! :code.lib_dir(:dynamo)
   end
 
   test "defines root based on user config" do


### PR DESCRIPTION
Changed over all records (except one defrecordp, [connection](https://github.com/dynamo/dynamo/blob/master/lib/dynamo/connection/behaviour.ex#L66)) to structs (thanks @alco for helping!).

Using Binary.Dict to get rid of deprecation warning "Using records with the Dict module is deprecated, please use structs instead", maybe this should be extracted out of Dynamo?

Couldn't find what happened to `__ENV__.location`, replaced with `__ENV__.file` and `__ENV__.line` instead in tests.

The following lines still report deprecation warnings:
- test/dynamo_test.exs:40 DynamoTest."test defines root based on otp app"/1
- lib/dynamo/static.ex:45 Dynamo.Static.init/1
  Deprecation warning: "String.from_char_list!/1 is deprecated, please use String.from_char_data!/1 instead". 

These lines do not utilize Sting.from_char_list!/1, error line reporting incorrect?
