### PR TITLE
Replace lc/bc comprehensions with 'for'

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ To display the list of fruits, `fruits.html.eex` might look like:
 <html>
 <body>
   <ul>
-  <%= lc { id, name } inlist @fruits do %>
+  <%= for { id, name } <- @fruits do %>
     <li><a href="/fruit/<%= id %>"><%= name %></a></li>
   <% end %>
   </ul>

--- a/examples/simple_ecto/web/templates/index.html.eex
+++ b/examples/simple_ecto/web/templates/index.html.eex
@@ -14,7 +14,7 @@
             <th>Avg High</th>
             <th>Precipitation</th>
           </tr>
-        <%= lc { _id, city, temp_lo, temp_hi, prcp } inlist @results do %>
+        <%= for { _id, city, temp_lo, temp_hi, prcp } <- @results do %>
           <tr>
             <td><%= city %></td>
             <td><%= temp_lo %></td>

--- a/lib/binary/dict.ex
+++ b/lib/binary/dict.ex
@@ -36,12 +36,12 @@ defmodule Binary.Dict do
 
   @doc false
   def keys(dict(data)) do
-    lc { k, _ } inlist data, do: k
+    for { k, _ } <- data, do: k
   end
 
   @doc false
   def values(dict(data)) do
-    lc { _, v } inlist data, do: v
+    for { _, v } <- data, do: v
   end
 
   @doc false
@@ -123,7 +123,7 @@ defmodule Binary.Dict do
   end
 
   defp keydelete(data, key) do
-    lc { k, _ } = tuple inlist data, key != k, do: tuple
+    for { k, _ } = tuple <- data, key != k, do: tuple
   end
 
   defp keyupdate([{key, value}|dict], key, fun) do

--- a/lib/dynamo.ex
+++ b/lib/dynamo.ex
@@ -304,7 +304,7 @@ defmodule Dynamo do
     end
 
     templates_server = dynamo[:supervisor].TemplatesServer
-    templates_paths  = lc path inlist templates_paths do
+    templates_paths  = for path <- templates_paths do
       if is_binary(path) do
         Path.expand(path)
       else

--- a/lib/dynamo/cowboy/body_parser.ex
+++ b/lib/dynamo/cowboy/body_parser.ex
@@ -69,7 +69,7 @@ defmodule Dynamo.Cowboy.BodyParser do
     case List.keyfind(headers, "content-disposition", 0) do
       { _, disposition } ->
         [_|parts] = String.split(disposition, ";")
-        parts     = lc part inlist parts, do: split_equals(part)
+        parts     = for part <- parts, do: split_equals(part)
 
         case List.keyfind(parts, "name", 0) do
           { _, name } ->

--- a/lib/dynamo/filters/exceptions/debug.ex
+++ b/lib/dynamo/filters/exceptions/debug.ex
@@ -52,7 +52,7 @@ defmodule Dynamo.Filters.Exceptions.Debug do
     config  = dynamo.config[:dynamo]
     editor  = config[:exceptions_editor]
     sources = config[:source_paths] ++ config[:templates_paths]
-    sources = lc source inlist sources, path inlist Path.wildcard(Path.join(root, source)), do: path
+    sources = for source <- sources, path <- Path.wildcard(Path.join(root, source)), do: path
 
     Enum.map_reduce(stacktrace, 0, &each_frame(&1, &2, root, sources, editor)) |> elem(0)
   end

--- a/lib/dynamo/filters/exceptions/template.eex
+++ b/lib/dynamo/filters/exceptions/template.eex
@@ -409,13 +409,13 @@
         font-weight: bold;
         font-size: 10pt;
     }
-    
+
     .trace_info .title .location a {
         color:inherit;
         text-decoration:none;
         border-bottom:1px solid #aaaaaa;
     }
-    
+
     .trace_info .title .location a:hover {
         border-color:#666666;
     }
@@ -605,7 +605,7 @@
                 <a href="#" id="all_frames">All frames</a>
             </nav>
             <ul class="frames">
-                <%= lc frame inlist @frames do %>
+                <%= for frame <- @frames do %>
                     <li class="<%= frame.context %>" style="display: none" data-context="<%= frame.context %>" data-index="<%= frame.index %>">
                         <span class='stroke'></span>
                         <i class="icon <%= frame.context %>"></i>
@@ -626,7 +626,7 @@
         </nav>
 
         <div class="conn_info">
-            <%= lc frame inlist @frames do %>
+            <%= for frame <- @frames do %>
                 <div class="frame_info" id="frame_info_<%= frame.index %>" style="display: none;">
                     <header class="trace_info">
                         <div class="title">
@@ -636,7 +636,7 @@
 
                         <div class="code">
                           <%= if snippet = frame.snippet do %>
-                            <%= lc { index, line, highlight } inlist snippet do %>
+                            <%= for { index, line, highlight } <- snippet do %>
                               <pre class="<%= if highlight, do: "highlight" %>"><span class="ln"><%= index %></span><span><%=h line %></span></pre>
                             <% end %>
                           <% else %>

--- a/lib/dynamo/filters/static.ex
+++ b/lib/dynamo/filters/static.ex
@@ -31,7 +31,7 @@ defmodule Dynamo.Filters.Static do
   @doc false
   def service(conn, fun, { __MODULE__, path, root }) do
     segments = subset(path, conn.path_info_segments)
-    segments = lc segment inlist List.wrap(segments), do: URI.decode(segment)
+    segments = for segment <- List.wrap(segments), do: URI.decode(segment)
 
     cond do
       segments in [nil, []] ->

--- a/lib/dynamo/helpers/escaping.ex
+++ b/lib/dynamo/helpers/escaping.ex
@@ -8,7 +8,7 @@ defmodule Dynamo.Helpers.Escaping do
   Escapes HTML.
   """
   def h(string) do
-    bc <<code>> inbits to_string(string) do
+    for <<code>> <- to_string(string) do
       << case code do
            ?& -> "&amp;"
            ?< -> "&lt;"

--- a/lib/dynamo/helpers/escaping.ex
+++ b/lib/dynamo/helpers/escaping.ex
@@ -8,7 +8,7 @@ defmodule Dynamo.Helpers.Escaping do
   Escapes HTML.
   """
   def h(string) do
-    for <<code>> <- to_string(string) do
+    for <<code <- to_string(string)>> do
       << case code do
            ?& -> "&amp;"
            ?< -> "&lt;"

--- a/lib/dynamo/loader.ex
+++ b/lib/dynamo/loader.ex
@@ -73,7 +73,7 @@ defmodule Dynamo.Loader do
                 Code.unload_files [file]
                 :erlang.raise(kind, reason, stacktrace)
             end
-          modules = lc { mod, _ } inlist tuples, do: mod
+          modules = for { mod, _ } <- tuples, do: mod
           :gen_server.cast(__MODULE__, { :loaded, file, modules })
           :ok
         else
@@ -93,7 +93,7 @@ defmodule Dynamo.Loader do
     case :gen_server.call(__MODULE__, :conditional_purge) do
       :ok -> :ok
       { :purged, callbacks } ->
-        lc callback inlist callbacks, do: callback.()
+        for callback <- callbacks, do: callback.()
         :purged
     end
   end

--- a/lib/dynamo/router/base.ex
+++ b/lib/dynamo/router/base.ex
@@ -455,7 +455,7 @@ defmodule Dynamo.Router.Base do
     end
 
     unless vars == [] do
-      route_params = lc var inlist vars, do: { var, { var, [], nil } }
+      route_params = for var <- vars, do: { var, { var, [], nil } }
       hooks = quote do
         var!(conn) = var!(conn).route_params(unquote(route_params))
         unquote(hooks)

--- a/lib/dynamo/router/utils.ex
+++ b/lib/dynamo/router/utils.ex
@@ -60,7 +60,7 @@ defmodule Dynamo.Router.Utils do
 
   """
   def split(bin) do
-    lc segment inlist String.split(bin, "/"), segment != "", do: segment
+    for segment <- String.split(bin, "/"), segment != "", do: segment
   end
 
   ## Helpers
@@ -140,7 +140,7 @@ defmodule Dynamo.Router.Utils do
   end
 
   defp list_split(bin) do
-    lc segment inlist String.split(bin, "/"), segment != "", do: String.to_char_list!(segment)
+    for segment <- String.split(bin, "/"), segment != "", do: String.to_char_list!(segment)
   end
 
   defp binary_from_buffer(buffer) do

--- a/lib/dynamo/templates/finder.ex
+++ b/lib/dynamo/templates/finder.ex
@@ -41,7 +41,7 @@ defimpl Dynamo.Templates.Finder, for: BitString do
   end
 
   def all(root) do
-    lc path inlist Path.wildcard("#{root}/**/*.*") do
+    for path <- Path.wildcard("#{root}/**/*.*") do
       key = Path.relative_to path, root
       build(root, Path.rootname(key), path)
     end

--- a/lib/dynamo/templates/handler.ex
+++ b/lib/dynamo/templates/handler.ex
@@ -68,10 +68,10 @@ defmodule Dynamo.Templates.EEXHandler do
   end
 
   defp vars(locals) do
-    lc name inlist locals, do: { name, [], nil }
+    for name <- locals, do: { name, [], nil }
   end
 
   defp match(locals) do
-    lc var inlist locals, do: { :=, [], [{ :_, [], nil }, var] }
+    for var <- locals, do: { :=, [], [{ :_, [], nil }, var] }
   end
 end

--- a/lib/mix/tasks/compile.dynamo.ex
+++ b/lib/mix/tasks/compile.dynamo.ex
@@ -84,7 +84,7 @@ defmodule Mix.Tasks.Compile.Dynamo do
       end
 
       compiled = compile_files to_compile, compile_path, root
-      compiled = lc { mod, _ } inlist compiled, do: atom_to_binary(mod)
+      compiled = for { mod, _ } <- compiled, do: atom_to_binary(mod)
 
       Mix.Utils.write_manifest(manifest, compiled)
       compile_templates mod, dynamo[:compiled_templates], templates, compile_path
@@ -102,10 +102,10 @@ defmodule Mix.Tasks.Compile.Dynamo do
   end
 
   defp extract_templates(paths) do
-    lc path inlist paths,
+    for path <- paths,
        not Dynamo.Templates.Finder.requires_precompilation?(path),
        templates = Dynamo.Templates.Finder.all(path),
-       template inlist templates, do: template
+       template <- templates, do: template
   end
 
   defp template_mtime(Dynamo.Template[key: key, updated_at: updated_at]) do


### PR DESCRIPTION
They're getting deprecated in 0.13.2.

Tests are passing on my machine.
