### PR TITLE
Deps version rev and deprecation updates

### DIFF
--- a/lib/dynamo.ex
+++ b/lib/dynamo.ex
@@ -375,7 +375,7 @@ defmodule Dynamo do
         based on the OTP app directory.
         """
         def root do
-          :code.lib_dir(unquote(app)) |> String.from_char_list!
+          :code.lib_dir(unquote(app)) |> String.from_char_data!
         end
       end
     else

--- a/lib/dynamo/cowboy/body_parser.ex
+++ b/lib/dynamo/cowboy/body_parser.ex
@@ -90,7 +90,7 @@ defmodule Dynamo.Cowboy.BodyParser do
   defp get_tmp_dir(other), do: other
 
   defp split_equals(binary) do
-    case String.split(binary, "=", global: false) do
+    case String.split(binary, "=", parts: 2) do
       [h]   -> { trim(h), nil }
       [h,t] -> { trim(h), strip_quotes(t) }
     end

--- a/lib/dynamo/router/utils.ex
+++ b/lib/dynamo/router/utils.ex
@@ -140,7 +140,7 @@ defmodule Dynamo.Router.Utils do
   end
 
   defp list_split(bin) do
-    for segment <- String.split(bin, "/"), segment != "", do: String.to_char_list!(segment)
+    for segment <- String.split(bin, "/"), segment != "", do: List.from_char_data!(segment)
   end
 
   defp binary_from_buffer(buffer) do

--- a/lib/dynamo/templates/finder.ex
+++ b/lib/dynamo/templates/finder.ex
@@ -58,7 +58,7 @@ defimpl Dynamo.Templates.Finder, for: BitString do
   end
 
   defp escape(key) do
-    bc <<code>> inbits key do
+    for <<code <- key>>, into: "" do
       << if code in [?[, ?], ?{, ?}, ?*, ??] do
            << ?\\, code >>
          else

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,9 @@
-%{"cowboy": {:git, "git://github.com/extend/cowboy.git", "05024529679d1d0203b8dcd6e2932cc2a526d370", []},
+%{"cowboy": {:git, "git://github.com/extend/cowboy.git", "1ad3aae4d5459ee991805d16a3837e1da2ba96ff", []},
   "cowlib": {:git, "git://github.com/extend/cowlib.git", "f58340a0044856bb508df03cfe94cf79308380a2", [ref: "0.6.1"]},
   "ets_lru": {:git, "https://github.com/cloudant/ets_lru.git", "54df566f02412595f69500ce2326d31cfa55ae7a", [ref: "master"]},
   "hackney": {:git, "git://github.com/benoitc/hackney.git", "1a427d1e1820f89699b51228746e586e53d15cf9", [tag: "0.12.1"]},
   "hackney_lib": {:git, "https://github.com/benoitc/hackney_lib.git", "48a5a3fc64892c95e4e3efdd464f26ca5683d2f9", [tag: "0.3.0"]},
   "idna": {:git, "git://github.com/benoitc/erlang-idna.git", "21aa158b7f36bf2a000f12fe40d7f21eece9cf65", [tag: "hackney-0.11.2"]},
-  "mime": {:git, "git://github.com/dynamo/mime.git", "db84370c53a67a7e58a4d0cfb026f4edc64a9367", []},
+  "mime": {:git, "git://github.com/dynamo/mime.git", "ae4295d1dbec8dd36fe366cc2b78df07f573e673", []},
   "mimetypes": {:git, "git://github.com/spawngrid/mimetypes.git", "47d37a977a7d633199822bf6b08353007483d00f", [ref: "master"]},
   "ranch": {:git, "git://github.com/extend/ranch.git", "5df1f222f94e08abdcab7084f5e13027143cc222", [ref: "0.9.0"]}}


### PR DESCRIPTION
Gets rid of the rest of the deprecation warnings on elixir 0.13.2.

1 mix test still fails, and compile fails when using elixir HEAD.
