### PR TITLE
Fix for Mix.project deprecation

### DIFF
--- a/lib/mix/tasks/compile.dynamo.ex
+++ b/lib/mix/tasks/compile.dynamo.ex
@@ -59,8 +59,8 @@ defmodule Mix.Tasks.Compile.Dynamo do
     dynamo  = mod.config[:dynamo]
 
     compile_path = Mix.Project.compile_path
-    compile_exts = project[:elixirc_exts]
-    watch_exts   = project[:elixirc_watch_exts]
+    compile_exts = [:ex]
+    watch_exts   = [:ex, :eex, :exs]
     source_paths = dynamo[:source_paths]
     templates    = extract_templates(dynamo[:templates_paths])
 


### PR DESCRIPTION
It's intended to fix one test failure at v0.13.2.

```
(TokenMissingError) web/templates/index.html.eex:16: missing terminator: end (for \"do\" starting at line 12)
```

These params were deleted in the following commit.
https://github.com/elixir-lang/elixir/commit/a67fe46ca59710e38cce839d8202ddb8641459e2
