### PR TITLE
Update query_parser to use Record.record?

### DIFF
--- a/lib/dynamo/connection/behaviour.ex
+++ b/lib/dynamo/connection/behaviour.ex
@@ -61,9 +61,11 @@ defmodule Dynamo.Connection.Behaviour do
     ] ++ opts
 
     quote location: :keep do
+      import Record
+
       @behaviour Dynamo.Connection
 
-      defrecordp :connection, __MODULE__, unquote(fields)
+      Record.defrecordp :connection, __MODULE__, unquote(fields)
 
       ## Assigns
 

--- a/lib/dynamo/connection/query_parser.ex
+++ b/lib/dynamo/connection/query_parser.ex
@@ -1,6 +1,8 @@
 defmodule Dynamo.Connection.QueryParser do
   defexception ParseError, message: nil
 
+  import Record
+
   @moduledoc """
   Conveniences for parsing query strings in Dynamo.
 
@@ -68,7 +70,7 @@ defmodule Dynamo.Connection.QueryParser do
   # `age=17` would match here.
   defp assign_parts([key], acc, value) do
     Binary.Dict.update(acc, key, value, fn
-      x when is_list(x) or is_record(x, Binary.Dict) ->
+      x when is_list(x) or Record.record?(x, Binary.Dict) ->
         raise ParseError, message: "expected string at #{key}"
       x -> x
     end)
@@ -98,7 +100,7 @@ defmodule Dynamo.Connection.QueryParser do
   defp assign_parts([key|t], acc, value) do
     child =
       case Binary.Dict.get(acc, key) do
-        current when is_record(current, Binary.Dict) -> current
+        current when Record.record?(current, Binary.Dict) -> current
         nil -> Binary.Dict.new
         _   -> raise ParseError, message: "expected dict at #{key}"
       end

--- a/lib/dynamo/templates.ex
+++ b/lib/dynamo/templates.ex
@@ -28,12 +28,15 @@ defexception Dynamo.TemplateNotFound, query: nil, paths: nil do
 end
 
 defmodule Dynamo.Templates do
+
+  import Record
+
   @moduledoc false
 
   @doc """
   Finds the given template in any of the templates paths.
   """
-  def find(query, _tmpl_paths) when is_record(query, Template) do
+  def find(query, _tmpl_paths) when Record.record?(query, Template) do
     query
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Dynamo.Mixfile do
 
   def project do
     [ app: :dynamo,
-      elixir: "~> 0.13.0-dev",
+      elixir: "~> 0.13.3-dev",
       version: "0.1.0-dev",
       name: "Dynamo",
       source_url: "https://github.com/dynamo/dynamo",


### PR DESCRIPTION
This is an update for the 13.3-dev changes, switching is_record?/2 to Record.record?

Also update defrecordp/3 to Record.defrecordp/3

https://github.com/elixir-lang/elixir/blob/master/CHANGELOG.md
