### PR TITLE
use stable Elixir branch on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ notifications:
 otp_release:
   - 17.0
 before_install:
-  - git clone git://github.com/elixir-lang/elixir --depth 1
+  - git clone -b stable git://github.com/elixir-lang/elixir --depth 1
   - make -C elixir
 before_script: "export PATH=`pwd`/elixir/bin:$PATH"
 script: "MIX_ENV=test mix do deps.get, test"


### PR DESCRIPTION
I like green badges on the stuff I use as deps :]

You mentioned on irc you'd follow stable Elixir. Now the most generic way for travis to get this right (the other is to grab precompiled Elixir version each minor release). This will make your build green. Last time your travis build errored on deprecated hygiene stuff, which is ok in 0.13.3. Cheers
